### PR TITLE
fix: ensure lockfile is used for setup/install

### DIFF
--- a/docs/guide/src/setup.md
+++ b/docs/guide/src/setup.md
@@ -35,7 +35,7 @@ rustup target add wasm32-unknown-uknown
 We also recommend installing the Dioxus CLI. The Dioxus CLI automates building and packaging for various targets and integrates with simulators, development servers, and app deployment. To install the CLI, you'll need cargo (should be automatically installed with Rust):
 
 ```
-$ cargo install dioxus-cli
+$ cargo install dioxus-cli --locked
 ```
 
 You can update the dioxus-cli at any time with:


### PR DESCRIPTION
Currently the setup guide uses `cargo install [name]`, which will guarantee the install uses all the newest available semver-compatible versions of dependencies.

While normally this is ideal, in the specific case of dioxus-cli, it uses a prerelease of `notify`, specifically `notify-5.0.0-pre.4`, which is semver forward-compatible with all other 5.0.0 pre-releases. This poses the risk of semver-compatible breaking changes.

In the meantime I feel using `--locked` is an appropriate temporary solution. Currently this prevents building (at least on `x86_64-unknown-linux-gnu`):

![image](https://user-images.githubusercontent.com/8260240/147986470-d4a89b57-6df3-485f-bdf6-e448645c3f3d.png)

An alternative would be bumping your notify prerelease and fixing the incompatibilities. I would've just done that but it seems like the CLI itself is currently not a public repo (or at minimum I couldn't find the repo, and it's not included in the Cargo.toml for the cli crate).