### PR TITLE
Fixed misspelled command copy

### DIFF
--- a/docs/guide/setup.html
+++ b/docs/guide/setup.html
@@ -173,7 +173,7 @@
 <h3 id="installing-rust"><a class="header" href="#installing-rust">Installing Rust</a></h3>
 <p>Head over to <a href="http://rust-lang.org">https://rust-lang.org</a> and install the Rust compiler. </p>
 <p>Once installed, make sure to  install wasm32-unknown-unknown as a target if you're planning on deploying your app to the web.</p>
-<pre><code>rustup target add wasm32-unknown-uknown
+<pre><code>rustup target add wasm32-unknown-unknown
 </code></pre>
 <h3 id="dioxus-cli-for-dev-server-bundling-etc"><a class="header" href="#dioxus-cli-for-dev-server-bundling-etc">Dioxus-CLI for dev server, bundling, etc.</a></h3>
 <p>We also recommend installing the Dioxus CLI. The Dioxus CLI automates building and packaging for various targets and integrates with simulators, development servers, and app deployment. To install the CLI, you'll need cargo (should be automatically installed with Rust):</p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1195363/148087784-e42ea37f-43f7-4030-ac20-b1355b9f1a30.png)

Attempting to run the code as written ( `rustup target add wasm32-unknown-uknown` ) results in an error due to the misspelled `uknown` in the text. This edit fixes this.