### PR TITLE
Update to new use_state idioms

### DIFF
--- a/snippets/homepage.rs
+++ b/snippets/homepage.rs
@@ -1,9 +1,9 @@
 fn app(cx: Scope) -> Element {
-    let mut count = use_state(&cx, || 0);
+    let (count, set_count) = use_state(&cx, || 0);
 
     cx.render(rsx!(
         h1 { "High-Five counter: {count}" }
-        button { onclick: move |_| count += 1, "Up high!" }
-        button { onclick: move |_| count -= 1, "Down low!" }
+        button { onclick: move |_| set_count(count + 1), "Up high!" }
+        button { onclick: move |_| set_count(count - 1), "Down low!" }
     ))
 }

--- a/snippets/mod.rs
+++ b/snippets/mod.rs
@@ -18,12 +18,12 @@ fn Simple(cx: Scope) -> Element {
 ///
 /// Thanks to Rust's ownership rules, it's impossible to misuse the `use_state` hook.
 fn Stateful(cx: Scope) -> Element {
-    let mut count = use_state(&cx, || 0);
+    let (count, set_count) = use_state(&cx, || 0);
 
     cx.render(rsx! (
         button {
             "Upvote counter: {count}",
-            onclick: move |_| count += 1
+            onclick: move |_| set_count(count + 1)
         }
     ))
 }
@@ -52,7 +52,7 @@ fn Stateful(cx: Scope<PropBased>) -> Element {
 /// Elements are created with a dedicated memory allocator that intelligently reuses memory between renders. A component
 /// at "steady-state" performs zero global allocations, making rendering extremely fast and memory efficient.
 fn AdvancedRendering(cx: Scope) -> Element {
-    let should_show = use_state(&cx, || true);
+    let (should_show, _) = use_state(&cx, || true);
 
     cx.render(rsx! (
         button {

--- a/src/components/homepage/hero.rs
+++ b/src/components/homepage/hero.rs
@@ -36,7 +36,7 @@ pub fn Hero(cx: Scope) -> Element {
 }
 
 pub static InteractiveHeader: Component<()> = |cx| {
-    let mut count = use_state(&cx, || 0);
+    let (count, set_count) = use_state(&cx, || 0);
 
     cx.render(rsx!{
         div { class: "flex flex-col items-center py-3", background_color: "hsl(220, 13%, 18%)",
@@ -46,13 +46,13 @@ pub static InteractiveHeader: Component<()> = |cx| {
             div { class: "flex flex-row items-center",
                 button {
                     class: "inline-flex items-center text-white bg-green-500 border-0 py-1 px-4 focus:outline-none hover:bg-gray-600",
-                    onclick: move |_| count += 1,
+                    onclick: move |_| set_count(count + 1),
                     "Up high!"
                 }
                 img { class: "h-12 mx-4", src: "https://i.imgur.com/aK3dWXs.png" }
                 button {
                     class: "inline-flex items-center text-white bg-red-500 border-0 py-1 px-4 focus:outline-none hover:bg-gray-600",
-                    onclick: move |_| count -= 1,
+                    onclick: move |_| set_count(count - 1),
                     "Down low!"
                 }
             }

--- a/src/components/homepage/snippets.rs
+++ b/src/components/homepage/snippets.rs
@@ -2,8 +2,8 @@ use super::super::snippets::*;
 use dioxus::prelude::*;
 
 pub static Snippets: Component<()> = |cx| {
-    let (snippets, _) = use_state(&cx, build_snippets).classic();
-    let selected_snippet = use_state(&cx, || 0);
+    let (snippets, _) = use_state(&cx, build_snippets);
+    let (selected_snippet, set_selected_snippet) = use_state(&cx, || 0);
 
     cx.render(rsx! {
         section { class: "text-gray-500 bg-white body-font mx-auto px-6 lg:px-24 xl:px-48 pt-12",
@@ -20,7 +20,7 @@ pub static Snippets: Component<()> = |cx| {
                                 key: "{s.title}",
                                 cursor: "pointer",
                                 class: "p-3 pr-8 hover:bg-blue-500 hover:text-blue-100 {is_selected}",
-                                onclick: move |_| selected_snippet.set(id),
+                                onclick: move |_| set_selected_snippet(id),
                                 "{s.title}"
                             })
                         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use wasm_bindgen::prelude::*;
 pub fn start() {
     console_error_panic_hook::set_once();
     wasm_logger::init(wasm_logger::Config::new(log::Level::Debug));
-    dioxus::web::launch_with_props(app, (), |c| c.hydrate(true));
+    dioxus::web::launch_with_props(app, (), |c| c.hydrate(false));
 }
 
 pub fn app(cx: Scope) -> Element {
@@ -223,7 +223,7 @@ fn nav_header(cx: Scope) -> Element {
 }
 
 pub static InteractiveHeader: Component<()> = |cx| {
-    let mut count = use_state(&cx, || 0);
+    let (count, set_count) = use_state(&cx, || 0);
 
     cx.render(rsx!{
         div {
@@ -236,12 +236,13 @@ pub static InteractiveHeader: Component<()> = |cx| {
             div { class: "flex flex-col items-center",
                 button {
                     class: "inline-flex items-center text-white bg-green-500 border-0 py-1 px-4 focus:outline-none hover:bg-gray-600",
-                    onclick: move |_| count += 1, "Up high!"
+                    onclick: move |_| set_count(count + 1),
+                    "Up high!"
                 }
                 img { class: "h-12 mx-4 my-4", src: "https://rustacean.net/assets/rustacean-flat-gesture.png" }
                 button {
                     class: "inline-flex items-center text-white bg-red-500 border-0 py-1 px-4 focus:outline-none hover:bg-gray-600",
-                    onclick: move |_| count -= 1,
+                    onclick: move |_| set_count(count - 1),
                     "Down low!"
                 }
             }


### PR DESCRIPTION
Proposed fix #16 

After switching to the new api I had to remove the classic option from the snippets.
I believe this led to a runtime error. The workaround was to turn off the hydrate option at lib.rs:30

Without the workaround, the chrome debugger gave me:
index-a8c51738657fa0e7.js:461 panicked at 'called `Option::unwrap()` on a `None` value', /Users/ctarrington/.cargo/registry/src/github.com-1ecc6299db9ec823/dioxus-web-0.0.5/src/rehydrate.rs:105:22

Hope this helps someone more familiar with the API restore the old functionality. Or if you want to give me a thread to pull on I can take a closer look.

With the workaround everything compiles and runs. I fixed the samples in the home page.

Also, thanks for making this amazing framework!!