### PR TITLE
Update hero.rs - fix "jumping" on click

### DIFF
--- a/src/components/homepage/hero.rs
+++ b/src/components/homepage/hero.rs
@@ -60,8 +60,8 @@ pub fn InteractiveHeader(cx: Scope) -> Element {
             class: "flex flex-col items-center px-10 rounded mt-6 mb-2 pt-4 mr-auto hidden lg:block lg:ml-2" ,
             background_color: "hsl(220, 13%, 18%)",
 
-            div { class: "pb-3 text-white",
-                h1 { "High-Five counter: {count}" }
+            div { class: "pb-3 text-white text-center w-44",
+                h1 { "Counter: {count}" }
             }
             div { class: "flex flex-col items-center",
                 button {


### PR DESCRIPTION
The styling had a quirk - as the count changed, the width of the text would change, and that would cause some resizing. 

Since it's within a centered layout, it made it look like the whole code sample and example were "jumping" a little: 

![original](https://user-images.githubusercontent.com/2420688/154786706-078f623b-a936-4240-9687-f15507f81899.gif)