### PR TITLE
Fix platform getting started links

### DIFF
--- a/src/components/homepage/mod.rs
+++ b/src/components/homepage/mod.rs
@@ -108,7 +108,7 @@ fn AvailablePlatforms(cx: Scope) -> Element {
                     right: render!(
     "Build for the web using Rust and WebAssembly. As fast as SolidJS and more robust than React. Integrated hot reloading for instant iterations."
 ),
-                    to: "https://dioxuslabs.com/reference/web",
+                    to: "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/web.html",
                     title: "Web with WASM"
                 }
                 TriShow {
@@ -117,11 +117,11 @@ fn AvailablePlatforms(cx: Scope) -> Element {
                     right: render!(
     "Lightweight (<2mb) desktop and mobile apps with zero configuration. Choose between WebView or WGPU-enabled renderers. Runs on macOS, Windows, Linux, iOS, and Android."
 ),
-                    to: "https://dioxuslabs.com/reference/desktop",
+                    to: "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/desktop.html",
                     title: "Desktop and Mobile"
                 }
                 TriShow {
-                    to: "https://github.com/DioxusLabs/dioxus/tree/master/packages/tui",
+                    to: "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/tui.html",
                     title: "Terminal User Interfaces",
                     right: render!(
     "Quickly convert any CLI tool to a beautiful interactive user interface with just a few lines of code. Runs anywhere with a terminal."
@@ -130,7 +130,7 @@ fn AvailablePlatforms(cx: Scope) -> Element {
                     center: render!("")
                 }
                 TriShow {
-                    to: "https://dioxuslabs.com/reference/ssr",
+                    to: "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/ssr.html",
                     title: "Fullstack Apps",
                     right: render!(
     "Pre-render on the server, and hydrate on the client. Perfect lighthouse scores and performance over 1000x better than Node and Python. Perfect for static site generation or fullstack apps."
@@ -139,7 +139,7 @@ fn AvailablePlatforms(cx: Scope) -> Element {
                     center: render!("")
                 }
                 TriShow {
-                    to: "https://github.com/DioxusLabs/dioxus/tree/master/packages/liveview",
+                    to: "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/liveview.html",
                     title: "LiveView and LiveComponents",
                     right: render!(
     "Render your app entirely on the server. Zero backend configuration capable of handling thousands of active clients. Integrates with Axum, Warp, Salvo, and Tokamak.",


### PR DESCRIPTION
Updates these links to the new doc URL:
![image](https://user-images.githubusercontent.com/66571940/221215097-d1dfa98b-9eba-4043-9d57-69e44847eb72.png)
