### PR TITLE
Make a note that hot reloading does not work on stable

### DIFF
--- a/docs/0.3/guide/en/getting_started/hot_reload.html
+++ b/docs/0.3/guide/en/getting_started/hot_reload.html
@@ -180,16 +180,9 @@ Hot reloading is automatically enabled when using the web renderer on debug buil
 <li>Save and watch the style change without recompiling</li>
 </ol>
 <h1 id="desktopliveviewtui"><a class="header" href="#desktopliveviewtui">Desktop/Liveview/TUI</a></h1>
-<p>For desktop, LiveView, and tui, you can place the hot reload macro at the top of your main function to enable hot reloading.
-Hot reloading is automatically enabled on debug builds.</p>
-<p>For more information about hot reloading on native platforms and configuration options see the <a href="https://crates.io/crates/dioxus-hot-reload">dioxus-hot-reload</a> crate.</p>
-<h2 id="setup-1"><a class="header" href="#setup-1">Setup</a></h2>
-<p>Add the following to your main function:</p>
-<pre><pre class="playground"><code class="language-rust edition2018">fn main() {
-    hot_reload_init!();
-    // launch your application
-}
-</code></pre></pre>
+<blockquote>
+<p>Desktop, LiveView, and TUI currently only support hot reloading on the git version of dioxus. If you are interested in using hot reloading on these renderers, try installing the git version of dioxus and following the <a href="https://dioxuslabs.com/docs/nightly/guide/en/getting_started/hot_reload.html#desktopliveviewtui">nightly guide</a>.</p>
+</blockquote>
 <h2 id="usage-1"><a class="header" href="#usage-1">Usage</a></h2>
 <ol>
 <li>Run:</li>


### PR DESCRIPTION
Because we cannot release hot reloading until the 0.4 release, hot reloading is currently not working for non-web platform. This PR adds a note to the docs that points to the nightly version if users want hot reloading for these platforms