### PR TITLE
fix: links to `cli` package

### DIFF
--- a/src/components/footer.rs
+++ b/src/components/footer.rs
@@ -25,7 +25,10 @@ pub static Footer: Component<()> = |cx| {
             "Projects",
             &[
                 ("Dioxus", "https://github.com/DioxusLabs/dioxus"),
-                ("CLI", "https://github.com/DioxusLabs/cli"),
+                (
+                    "CLI",
+                    "https://github.com/DioxusLabs/dioxus/tree/master/packages/cli",
+                ),
                 ("Taffy", "https://github.com/DioxusLabs/taffy"),
             ],
         ),

--- a/src/components/nav.rs
+++ b/src/components/nav.rs
@@ -140,7 +140,10 @@ static LINKS: &[(&str, &str, LinkPairs)] = &[
                 "https://github.com/DioxusLabs/dioxus/tree/master/packages/router",
             ),
             ("Taffy", "https://github.com/DioxusLabs/taffy"),
-            ("CLI", "https://github.com/DioxusLabs/cli"),
+            (
+                "CLI",
+                "https://github.com/DioxusLabs/dioxus/tree/master/packages/cli",
+            ),
         ],
     ),
     (


### PR DESCRIPTION
Change [`https://github.com/DioxusLabs/cli`](https://github.com/DioxusLabs/cli) to [`https://github.com/DioxusLabs/dioxus/tree/master/packages/cli`](https://github.com/DioxusLabs/dioxus/tree/master/packages/cli)