### PR TITLE
Improve build times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,14 @@ pretty_assertions = { version = "1.4.0", optional = true }
 opt-level = 'z'
 strip = "debuginfo"
 
+[profile.dev.build-override]
+opt-level = 2
+codegen-units = 256
+
+[profile.release.build-override]
+opt-level = 2
+codegen-units = 256
+
 [patch.crates-io]
 dioxus-core = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.0" }
 dioxus-html = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.0" }


### PR DESCRIPTION
https://github.com/DioxusLabs/include_mdbook does some heavy work at compile time. The default cargo profile will run this in debug mode even when you pass the `--release` flag. This PR changes the config so that the package will run in closer to release mode. This changes the time it takes to build the md book from `7s` to `1s`