### PR TITLE
add fade-in to /awesome error text so it doesn't flash on screen when switching to that page

### DIFF
--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -614,10 +614,6 @@ video {
   top: 0px;
 }
 
-.isolate {
-  isolation: isolate;
-}
-
 .z-10 {
   z-index: 10;
 }
@@ -1097,8 +1093,18 @@ video {
   flex-basis: 0px;
 }
 
-.transform {
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-fadein-medium {
+  animation: fadein 500ms ease-in-out forwards;
 }
 
 .cursor-default {
@@ -1193,12 +1199,6 @@ video {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
-}
-
-.divide-y > :not([hidden]) ~ :not([hidden]) {
-  --tw-divide-y-reverse: 0;
-  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
-  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
 }
 
 .divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -1923,11 +1923,6 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-.text-emerald-50 {
-  --tw-text-opacity: 1;
-  color: rgb(236 253 245 / var(--tw-text-opacity));
-}
-
 .underline {
   text-decoration-line: underline;
 }
@@ -1974,10 +1969,6 @@ video {
 .outline-none {
   outline: 2px solid transparent;
   outline-offset: 2px;
-}
-
-.outline {
-  outline-style: solid;
 }
 
 .invert {

--- a/src/components/awesome/mod.rs
+++ b/src/components/awesome/mod.rs
@@ -127,7 +127,7 @@ pub fn Awesome(cx: Scope) -> Element {
                 section {
                     class: "dark:bg-ideblack w-full pt-24 pb-96",
                     div {
-                        class: "container mx-auto max-w-screen-1g text-center",
+                        class: "container mx-auto max-w-screen-1g text-center animate-fadein-medium",
                         p {
                             class: "text-[3.3em] font-bold tracking-tight dark:text-white text-ghdarkmetal mb-2 px-2",
                             "It seems a not-so-awesome error occurred. 🙁"
@@ -145,7 +145,7 @@ pub fn Awesome(cx: Scope) -> Element {
                 section {
                     class: "dark:bg-ideblack w-full pt-24 pb-96",
                     div {
-                        class: "container mx-auto max-w-screen-1g text-center",
+                        class: "container mx-auto max-w-screen-1g text-center animate-fadein-medium",
                         p {
                             class: "text-[3.3em] font-bold tracking-tight dark:text-white text-ghdarkmetal mb-2 px-2",
                             "That's weird. There isn't anything awesome to show. 🙁"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,15 @@ module.exports = {
         // cutesy: "0px 0px 30px -10px red",
         pop: "0px 0px 30px -10px rgba(0, 0, 0, 0.5)",
       },
+      keyframes: {
+        fadein: {
+          'from': { opacity: '0' },
+          'to': { opacity: '1' },
+        }
+      },
+      animation: {
+        'fadein-medium': 'fadein 500ms ease-in-out forwards',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
now the text is not flashed on screen when switching to /awesome (see video)

there are also some changes made to tailwind.css by Tailwind, even though I used the same version as stated in that file's header (3.3.2). Not sure what that's about, I can remove them if needed.

https://github.com/DioxusLabs/docsite/assets/64774344/c6a17674-81d0-4fce-b980-8f0d01576e65



