### PR TITLE
fix: Update Fullstack's `Getting started` 404 link

### DIFF
--- a/docs-src/0.4/en/reference/fullstack/server_functions.md
+++ b/docs-src/0.4/en/reference/fullstack/server_functions.md
@@ -10,7 +10,7 @@ To make a server function, simply add the `#[server(YourUniqueType)]` attribute 
 
 You must call `register` on the type you passed into the server macro in your main function before starting your server to tell Dioxus about the server function.
 
-Let's continue building on the app we made in the [getting started](../../../getting_startedw/web/fullstack.md) guide. We will add a server function to our app that allows us to double the count on the server.
+Let's continue building on the app we made in the [getting started](../../getting_started/fullstack.md) guide. We will add a server function to our app that allows us to double the count on the server.
 
 First, add serde as a dependancy:
 


### PR DESCRIPTION
This was causing a dead link in https://dioxuslabs.com/learn/0.4/reference/fullstack/server_functions `getting started` link