### PR TITLE
fix overlap between hero and code snippet sections

### DIFF
--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -614,6 +614,10 @@ video {
   top: 0px;
 }
 
+.isolate {
+  isolation: isolate;
+}
+
 .z-10 {
   z-index: 10;
 }
@@ -1091,6 +1095,10 @@ video {
 
 .basis-0 {
   flex-basis: 0px;
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 @keyframes fadein {
@@ -1971,6 +1979,10 @@ video {
   outline-offset: 2px;
 }
 
+.outline {
+  outline-style: solid;
+}
+
 .invert {
   --tw-invert: invert(100%);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
@@ -2761,5 +2773,11 @@ video {
 @media (min-width: 1536px) {
   .\32xl\:max-w-\[30rem\] {
     max-width: 30rem;
+  }
+}
+
+@media (min-height:1080px) {
+  .\[\@media\(min-height\:1080px\)\]\:h-screen {
+    height: 100vh;
   }
 }

--- a/src/components/homepage/hero.rs
+++ b/src/components/homepage/hero.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 pub fn Hero(cx: Scope) -> Element {
     cx.render(rsx! {
-        section { class: "w-full dark:bg-ideblack h-screen",
+        section { class: "w-full dark:bg-ideblack [@media(min-height:1080px)]:h-screen",
             div { class: "flex flex-wrap items-center pb-12 px-3 md:px-12 max-w-screen-2xl mx-auto text-center my-auto h-full",
                 div { class: "relative w-full mx-4 sm:mx-auto text-gray-600",
                     div { class: "text-[3em] md:text-[5em] font-semibold dark:text-white text-ghdarkmetal font-sans py-12 flex flex-col",


### PR DESCRIPTION
In devices with smaller height, there is an overlap between hero section and code snippet section. I have added a one off media query to only use `height: 100vh` on devices with 1080px height or more. 

![image](https://github.com/DioxusLabs/docsite/assets/28825727/6d0052f2-1195-4acd-8026-a474d515ac88)
