### PR TITLE
fix: drop repeated phrase

### DIFF
--- a/docs-src/0.4/en/guide/state.md
+++ b/docs-src/0.4/en/guide/state.md
@@ -39,7 +39,7 @@ You can create state in dioxus using hooks. Hooks are Rust functions that take a
 In this case, we will use the `use_shared_state_provider` and `use_shared_state` hooks:
 
 - You can provide a closure to `use_shared_state_provider` that determines the initial value of the shared state and provides the value to all child components
-- You can use the You can then use the `use_shared_state` hook to read and modify that state in the `Preview` and `StoryListing` components
+- You can then use the `use_shared_state` hook to read and modify that state in the `Preview` and `StoryListing` components
 - When the value updates, `use_shared_state` will make the component re-render, and provides you with the new value
 
 > Note: You should prefer local state hooks like use_state or use_ref when you only use state in one component. Because we use state in multiple components, we can use a [global state pattern](../reference/context.md)


### PR DESCRIPTION
There was a typo on the [guide state section](https://dioxuslabs.com/learn/0.4/guide/state#state)