### PR TITLE
fix: Update use_window hook docs link in Desktop Reference

### DIFF
--- a/docs-src/0.4/en/reference/desktop/index.md
+++ b/docs-src/0.4/en/reference/desktop/index.md
@@ -23,4 +23,4 @@ You can link to local assets in dioxus desktop instead of using a url:
 
 ## Integrating with Wry
 
-In cases where you need more low level control over your window, you can use wry APIs exposed through the [Desktop Config](https://docs.rs/dioxus-desktop/0.3.0/dioxus_desktop/struct.Config.html) and the [use_window hook](https://docs.rs/dioxus-desktop/0.3.0/dioxus_desktop/struct.DesktopContext.html)
+In cases where you need more low level control over your window, you can use wry APIs exposed through the [Desktop Config](https://docs.rs/dioxus-desktop/0.3.0/dioxus_desktop/struct.Config.html) and the [use_window hook](https://docs.rs/dioxus-desktop/0.4.0/dioxus_desktop/fn.use_window.html)


### PR DESCRIPTION
Dioxus-desktop 0.4.0 docs are failing right now, I opened this [Pull Request](https://github.com/DioxusLabs/dioxus/pull/1295) hoping it will solve it , so the new link will not work until it is resolved.