### PR TITLE
added tailwind comment for when using router

### DIFF
--- a/docs-src/0.4/en/cookbook/tailwind.md
+++ b/docs-src/0.4/en/cookbook/tailwind.md
@@ -80,6 +80,9 @@ One popular option for styling your Dioxus application is [Tailwind](https://tai
     # which files or dirs will be watcher monitoring
     watch_path = ["src", "public"]
 
+    # uncomment line below if using Router
+    # index_on_404 = true
+
     # include `assets` in web platform
     [web.resource]
 


### PR DESCRIPTION
I added this comment in the tailwind section. Currently, not having this line breaks routing when you have a Dioxus.toml file as it'll return a 404 error instead of going to whatever page you wanted to go to.