### PR TITLE
Fixing links in Testing Documentation for Playwright

### DIFF
--- a/docs-src/0.4/en/cookbook/testing.md
+++ b/docs-src/0.4/en/cookbook/testing.md
@@ -41,6 +41,6 @@ webServer: [
 ],
 ```
 
-- [Web example](https://github.com/DioxusLabs/dioxus/tree/master/playwrite-tests/web)
-- [Liveview example](https://github.com/DioxusLabs/dioxus/tree/master/playwrite-tests/liveview)
-- [Fullstack example](https://github.com/DioxusLabs/dioxus/tree/master/playwrite-tests/fullstack)
+- [Web example](https://github.com/DioxusLabs/dioxus/tree/master/playwright-tests/web)
+- [Liveview example](https://github.com/DioxusLabs/dioxus/tree/master/playwright-tests/liveview)
+- [Fullstack example](https://github.com/DioxusLabs/dioxus/tree/master/playwright-tests/fullstack)


### PR DESCRIPTION
- Noticed that 3 links from the Testing docs are broken, due to a typo (playwrite instead of playwright)
- Amazing job adding this documentation!