### PR TITLE
Fix mandatory item emoji indicator

### DIFF
--- a/docs-src/0.4/en/CLI/configure.md
+++ b/docs-src/0.4/en/CLI/configure.md
@@ -62,7 +62,7 @@ Web-specific configuration.
    base_path = "my_application"
    ```
 
-### Web.Watcher ✍
+### Web.Watcher 🔒
 
 ```toml
 [web.watcher]


### PR DESCRIPTION
Replace "✍" with "🔒"