### PR TITLE
`Event Listeners` -> `Event Handlers` in the nav sidebar

### DIFF
--- a/docs-src/0.4/SUMMARY.md
+++ b/docs-src/0.4/SUMMARY.md
@@ -22,7 +22,7 @@
   - [RSX](reference/rsx.md)
   - [Components](reference/components.md)
   - [Props](reference/component_props.md)
-  - [Event Listeners](reference/event_handlers.md)
+  - [Event Handlers](reference/event_handlers.md)
   - [Hooks](reference/hooks.md)
   - [User Input](reference/user_input.md)
   - [Context](reference/context.md)


### PR DESCRIPTION
This chapter is called `Event Handlers` everywhere except on the navigation sidebar (`SUMMARY.md`).