### PR TITLE
Change `CatchAll` segment definition to `:..x` from `:...x`

### DIFF
--- a/docs-src/0.4/en/reference/router.md
+++ b/docs-src/0.4/en/reference/router.md
@@ -62,7 +62,7 @@ enum Route {
 enum Route {
 	#[route("/home")]
 	//  if the current location doesn't match any of the above routes, redirect to "/home"
-	#[redirect("/:...segments", |segments: Vec<String>| Route::Home {})]
+	#[redirect("/:..segments", |segments: Vec<String>| Route::Home {})]
 	Home {}
 	#[route("/blog")]
 	Blog {}

--- a/docs-src/0.4/en/router/reference/routes/index.md
+++ b/docs-src/0.4/en/router/reference/routes/index.md
@@ -40,7 +40,7 @@ The segment can be of any type that implements `FromStr`.
 
 ## Catch All Segments
 
-Catch All segments are in the form of `:...name` where `name` is the name of the field in the route variant. If the segments are parsed successfully then the route matches, otherwise the matching continues.
+Catch All segments are in the form of `:..name` where `name` is the name of the field in the route variant. If the segments are parsed successfully then the route matches, otherwise the matching continues.
 
 The segment can be of any type that implements `FromSegments`. (Vec<String> implements this by default)
 

--- a/src/doc_examples/catch_all_segments.rs
+++ b/src/doc_examples/catch_all_segments.rs
@@ -6,7 +6,7 @@ use dioxus_router::prelude::*;
 #[derive(Routable, Clone)]
 #[rustfmt::skip]
 enum Route {
-    // segments that start with :... are catch all segments
+    // segments that start with :.. are catch all segments
     #[route("/blog/:..segments")]
     BlogPost {
         // You must include catch all segment in child variants


### PR DESCRIPTION
In certain places 3 dots were used instead of 2.