### PR TITLE
Change invalid "listeners" link to valid "event handlers" link

### DIFF
--- a/docs-src/0.4/en/reference/rsx.md
+++ b/docs-src/0.4/en/reference/rsx.md
@@ -26,7 +26,7 @@ DemoFrame {
 
 ### Attributes
 
-Attributes (and [listeners](index.md)) modify the behavior or appearance of the element they are attached to. They are specified inside the `{}` brackets, using the `name: value` syntax. You can provide the value as a literal in the RSX:
+Attributes (and [event handlers](event_handlers.md)) modify the behavior or appearance of the element they are attached to. They are specified inside the `{}` brackets, using the `name: value` syntax. You can provide the value as a literal in the RSX:
 
 ```rust, no_run
 {{#include src/doc_examples/rsx_overview.rs:attributes}}


### PR DESCRIPTION
`[listeners](index.md)` -> `[event handlers](event_handlers.md)`. I assume it's a mistake since the link leads to 404.