### PR TITLE
Add config docs for desktop and TUI

### DIFF
--- a/docs-src/0.4/en/CLI/configure.md
+++ b/docs-src/0.4/en/CLI/configure.md
@@ -9,6 +9,82 @@ Some headers are mandatory, but none of the keys inside them are.
 In that case, you only need to include the header, but no keys.
 It might look weird, but it's normal.
 
+## Desktop and TUI
+
+For the desktop and TUI (terminal user interface) renderers, 
+Dioxus bundles your app using `dx bundle` and the [tauri-bundler](https://docs.rs/crate/tauri-bundler/latest).
+
+Tauri uses a JSON file for the configuration, but Dioxus uses TOML. So this:
+```json
+{
+  "package": {
+    "productName": "Your Awesome App",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "active": true,
+      "identifier": "com.my.app",
+      "shortDescription": "",
+      "longDescription": "",
+      "copyright": "Copyright (c) You 2021. All rights reserved.",
+      "icon": [
+        "icons/32x32.png",
+        "icons/128x128.png",
+        "icons/128x128@2x.png",
+        "icons/icon.icns",
+        "icons/icon.ico"
+      ],
+      "resources": ["./assets/**/*.png"],
+      "deb": {
+        "depends": ["debian-dependency1", "debian-dependency2"]
+      },
+      "macOS": {
+        "frameworks": [],
+        "minimumSystemVersion": "10.11",
+        "license": "./LICENSE"
+      },
+      "externalBin": ["./sidecar-app"]
+    }
+  }
+}
+```
+
+becomes this (we remove the `tauri`):
+
+```toml
+[package]
+productName = "Your Awesome App"
+version = "0.1.0"
+
+[bundle]
+active = true
+identifier = "com.my.app"
+shortDescription = ""
+longDescription = ""
+copyright = "Copyright (c) You 2021. All rights reserved."
+icon = [
+  "icons/32x32.png",
+  "icons/128x128.png",
+  "icons/128x128@2x.png",
+  "icons/icon.icns",
+  "icons/icon.ico"
+]
+resources = [ "./assets/**/*.png" ]
+externalBin = [ "./sidecar-app" ]
+
+[bundle.deb]
+depends = [ "debian-dependency1", "debian-dependency2" ]
+
+[bundle.macOS]
+frameworks = [ ]
+minimumSystemVersion = "10.11"
+license = "./LICENSE"
+```
+
+You can check out the [tauri-bundler docs.rs](https://docs.rs/tauri-bundler/latest/tauri_bundler/bundle/index.html). 
+This covers all the different values. Keep in mind that `FooSettings` becomes just `foo`.
+
 ## Structure
 
 Each header has its TOML form directly under it.

--- a/docs-src/0.4/en/CLI/configure.md
+++ b/docs-src/0.4/en/CLI/configure.md
@@ -9,82 +9,6 @@ Some headers are mandatory, but none of the keys inside them are.
 In that case, you only need to include the header, but no keys.
 It might look weird, but it's normal.
 
-## Desktop and TUI
-
-For the desktop and TUI (terminal user interface) renderers, 
-Dioxus bundles your app using `dx bundle` and the [tauri-bundler](https://docs.rs/crate/tauri-bundler/latest).
-
-Tauri uses a JSON file for the configuration, but Dioxus uses TOML. So this:
-```json
-{
-  "package": {
-    "productName": "Your Awesome App",
-    "version": "0.1.0"
-  },
-  "tauri": {
-    "bundle": {
-      "active": true,
-      "identifier": "com.my.app",
-      "shortDescription": "",
-      "longDescription": "",
-      "copyright": "Copyright (c) You 2021. All rights reserved.",
-      "icon": [
-        "icons/32x32.png",
-        "icons/128x128.png",
-        "icons/128x128@2x.png",
-        "icons/icon.icns",
-        "icons/icon.ico"
-      ],
-      "resources": ["./assets/**/*.png"],
-      "deb": {
-        "depends": ["debian-dependency1", "debian-dependency2"]
-      },
-      "macOS": {
-        "frameworks": [],
-        "minimumSystemVersion": "10.11",
-        "license": "./LICENSE"
-      },
-      "externalBin": ["./sidecar-app"]
-    }
-  }
-}
-```
-
-becomes this (we remove the `tauri`):
-
-```toml
-[package]
-productName = "Your Awesome App"
-version = "0.1.0"
-
-[bundle]
-active = true
-identifier = "com.my.app"
-shortDescription = ""
-longDescription = ""
-copyright = "Copyright (c) You 2021. All rights reserved."
-icon = [
-  "icons/32x32.png",
-  "icons/128x128.png",
-  "icons/128x128@2x.png",
-  "icons/icon.icns",
-  "icons/icon.ico"
-]
-resources = [ "./assets/**/*.png" ]
-externalBin = [ "./sidecar-app" ]
-
-[bundle.deb]
-depends = [ "debian-dependency1", "debian-dependency2" ]
-
-[bundle.macOS]
-frameworks = [ ]
-minimumSystemVersion = "10.11"
-license = "./LICENSE"
-```
-
-You can check out the [tauri-bundler docs.rs](https://docs.rs/tauri-bundler/latest/tauri_bundler/bundle/index.html). 
-This covers all the different values. Keep in mind that `FooSettings` becomes just `foo`.
-
 ## Structure
 
 Each header has its TOML form directly under it.
@@ -267,4 +191,101 @@ script = []
 
 [[web.proxy]]
 backend = "http://localhost:8000/api/"
+```
+
+## Desktop and TUI
+
+For the desktop and TUI (terminal user interface) renderers,
+Dioxus bundles your app using `dx bundle` and the [tauri-bundler](https://docs.rs/crate/tauri-bundler/latest).
+
+You can check out the [tauri-bundler docs.rs](https://docs.rs/tauri-bundler/latest/tauri_bundler/bundle/index.html).
+This covers all the different settings. Keep in mind that `FooSettings` becomes just `foo` in the TOML.
+
+Tauri uses a JSON file for the configuration, but Dioxus uses TOML. So this tauri-bundler example:
+```json
+{
+  "package": {
+    "productName": "Your Awesome App",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "active": true,
+      "identifier": "com.my.app",
+      "shortDescription": "",
+      "longDescription": "",
+      "copyright": "Copyright (c) You 2021. All rights reserved.",
+      "icon": [
+        "icons/32x32.png",
+        "icons/128x128.png",
+        "icons/128x128@2x.png",
+        "icons/icon.icns",
+        "icons/icon.ico"
+      ],
+      "resources": ["./assets/**/*.png"],
+      "deb": {
+        "depends": ["debian-dependency1", "debian-dependency2"]
+      },
+      "macOS": {
+        "frameworks": [],
+        "minimumSystemVersion": "10.11",
+        "license": "./LICENSE"
+      },
+      "externalBin": ["./sidecar-app"]
+    }
+  }
+}
+```
+
+needs to be translated to TOML.
+
+However, Dioxus has Dioxus-specific mandatory TOML fields that we need to include as well. 
+We can see what fields are mandatory from the documentation above.
+
+Additionally, we also need to remove `tauri` from the TOML headers.
+
+This is our final `Dioxus.toml`:
+
+```toml
+# From Dioxus
+[application]
+name = "Your Awesome App"
+default_platform = "desktop"
+
+# You might only be running on desktop, but the following "web" values are still required.
+[web.app]
+title = "Awesome"
+
+[web.watcher]
+
+[web.resource.dev]
+
+# From the tauri-bundler.
+[package]
+productName = "Your Awesome App"
+version = "0.1.0"
+
+[bundle]
+active = true
+identifier = "com.my.app"
+shortDescription = ""
+longDescription = ""
+copyright = "Copyright (c) You 2021. All rights reserved."
+icon = [
+  "icons/32x32.png",
+  "icons/128x128.png",
+  "icons/128x128@2x.png",
+  "icons/icon.icns",
+  "icons/icon.ico"
+]
+resources = [ "./assets/**/*.png" ]
+externalBin = [ "./sidecar-app" ]
+
+[bundle.deb]
+depends = [ "debian-dependency1", "debian-dependency2" ]
+
+[bundle.macOS]
+frameworks = [ ]
+minimumSystemVersion = "10.11"
+license = "./LICENSE"
 ```


### PR DESCRIPTION
Closes https://github.com/DioxusLabs/docsite/issues/334. This adds:
- Links to the `tauri-bundler` docs.
- Example [`Dioxus.toml`](https://github.com/DioxusLabs/docsite/pull/123/files#diff-434a92fe58a7862722dafd0a1ee9f739a26f377287b3c6a7a24b55d5cf8a8132R249) for desktop.

Please take a look at the example [`Dioxus.toml`](https://github.com/DioxusLabs/docsite/pull/123/files#diff-434a92fe58a7862722dafd0a1ee9f739a26f377287b3c6a7a24b55d5cf8a8132R249). I haven't tested it, I just *assumed* that's what it would look like.