### PR TITLE
Add "examples" page in the cookbook

### DIFF
--- a/docs-src/0.4/SUMMARY.md
+++ b/docs-src/0.4/SUMMARY.md
@@ -64,15 +64,16 @@
 ---
 - [Cookbook](cookbook/index.md)
   - [Publishing](cookbook/publishing.md)
+  - [Anti-patterns](cookbook/antipatterns.md)
+  - [Error Handling](cookbook/error_handling.md)
   - [Integrations](cookbook/integrations/index.md)
     - [Logging](cookbook/integrations/logging.md)
     - [Internationalization](cookbook/integrations/internationalization.md)
   - [State Management](cookbook/state/index.md)
     - [External State](cookbook/state/external/index.md)
     - [Custom Hooks](cookbook/state/custom_hooks/index.md)
-  - [Anti-patterns](cookbook/antipatterns.md)
-  - [Error Handling](cookbook/error_handling.md)
   - [Testing](cookbook/testing.md)
+  - [Examples](cookbook/examples.md)
   - [Tailwind](cookbook/tailwind.md)
   - [Custom Renderer](cookbook/custom_renderer.md)
 

--- a/docs-src/0.4/en/cookbook/examples.md
+++ b/docs-src/0.4/en/cookbook/examples.md
@@ -1,0 +1,21 @@
+# Examples
+
+There's a *lot* of these, so if you're having trouble implementing something, or you just want to see cool things
+that you can do with Dioxus, make sure to give these a look!
+
+Each of the examples in the main repository also has a permalink attached, in case the main one doesn't work.
+ However, permalinks lead to an older "archived" version, so if you're reading this a long time in the future in a galaxy far, far away...
+ The examples in the permalinks might not work.
+
+- [Main list](https://github.com/DioxusLabs/dioxus/tree/master/examples) - [permalink]((https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/examples)) - This is the largest list.
+- Package-specific examples from the [main repository](https://github.com/DioxusLabs/dioxus/). To learn more about these packages, search them up on [crates.io](https://crates.io/), or navigate from the examples to the root of the package.
+  - [dioxus-web](https://github.com/DioxusLabs/dioxus/tree/master/packages/web/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/web/examples)
+  - [dioxus-fullstack](https://github.com/DioxusLabs/dioxus/tree/master/packages/fullstack/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/fullstack/examples)
+  - [dioxus-liveview](shttps://github.com/DioxusLabs/dioxus/tree/master/packages/liveview/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/liveview/examples)
+  - [dioxus-router](https://github.com/DioxusLabs/dioxus/tree/master/packages/router/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/router/examples)
+  - [dioxus-tui](https://github.com/DioxusLabs/dioxus/tree/master/packages/dioxus-tui/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/dioxus-tui/examples)
+  - [plasmo ("rink" is the old name, it will be updated)](https://github.com/DioxusLabs/dioxus/tree/master/packages/rink/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/rink/examples)
+  - [rsx-rosetta](https://github.com/DioxusLabs/dioxus/tree/master/packages/rsx-rosetta/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/rsx-rosetta/examples)
+  - [native-core](https://github.com/DioxusLabs/dioxus/tree/master/packages/native-core/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/native-core/examples)
+  - [signals](https://github.com/DioxusLabs/dioxus/tree/master/packages/signals/examples) - [permalink](https://github.com/DioxusLabs/dioxus/tree/60ee82942c4decf67b6ad263f639553d9b7e28a9/packages/signals/examples) - This is unreleased, but it's a very exciting project, so stay tuned!
+- The [example-projects](https://github.com/DioxusLabs/example-projects) repository. It might be deprecated/removed in the future though. See [#25](https://github.com/DioxusLabs/example-projects/issues/25).

--- a/docs-src/0.4/en/cookbook/index.md
+++ b/docs-src/0.4/en/cookbook/index.md
@@ -4,8 +4,12 @@ The cookbook contains common recipes for different patterns within Dioxus.
 
 There are a few different sections in the cookbook:
 
-- [Anti-patterns](antipatterns.md) talks about what ingredients to avoid when developing your application
-- [Error Handling](error_handling.md) discusses best around about error handling in Dioxus
-- [Custom Renderer](custom_renderer.md) walks through the process of building a custom renderer for Dioxus
-- [State](state/index.md) discusses patterns around managing local, global, and external state in Dioxus
-- [Integrations](integrations/index.md) contains walkthroughs about integrating with external libraries 
+- [Publishing](publishing.md) will teach you how to present your app in a variety of delicious forms.
+- Explore the [Anti-patterns](antipatterns.md) section to discover what ingredients to avoid when preparing your application.
+- Within [Error Handling](error_handling.md), we'll master the fine art of managing spoiled ingredients in Dioxus.
+- Take a culinary journey through [State management](state/index.md), where we'll explore the world of handling local, global, and external state in Dioxus.
+- [Integrations](integrations/index.md) will guide you how to seamlessly blend external libraries into your Dioxus culinary creations.
+- [Testing](testing.md) explains how to examine the unique flavor of Dioxus-specific features, like components.
+- [Examples](examples.md) is a curated list of delightful recipes that demonstrate the various ways of using Dioxus ingredients.
+- [Tailwind](tailwind.md) reveals the secrets of combining your Tailwind and Dioxus ingredients into a complete meal. You will also learn about using other NPM ingredients (packages) with Dioxus.
+- In the [Custom Renderer](custom_renderer.md) section, we embark on a cooking adventure, inventing new ways to cook with Dioxus!


### PR DESCRIPTION
- Adds an "Examples" page in the cookbook which links to `example-projects` and all the examples in the main repository.
- Reorders links in `cookbook/index.md` and `SUMMARY.md` to match.
- Makes the cookbook sound a lot more like a *cook*book.