### PR TITLE
chore: `tauri-mobile` -> `cargo-mobile2`

### DIFF
--- a/docs-src/0.4/en/getting_started/mobile.md
+++ b/docs-src/0.4/en/getting_started/mobile.md
@@ -85,10 +85,10 @@ cargo new dioxus-mobile-test
 cd dioxus-mobile-test
 ```
 
-Next, we can use `tauri-mobile` to create a project for mobile:
+Next, we can use `cargo-mobile2` to create a project for mobile:
 
 ```shell
-cargo install --git https://github.com/tauri-apps/tauri-mobile
+cargo install --git https://github.com/tauri-apps/cargo-mobile2
 cargo mobile init
 ```
 


### PR DESCRIPTION
We have recently renamed `tauri-mobile` project to `cargo-mobile2` for SEO reasons.