### PR TITLE
Fix minor typos and consistency issues within the Guide

### DIFF
--- a/docs-src/0.4/en/guide/full_code.md
+++ b/docs-src/0.4/en/guide/full_code.md
@@ -1,6 +1,7 @@
 # Conclusion
 
-Well done! You've completed the Dioxus guide and built a hackernews application in Dioxus.
+Well done! You've completed the Dioxus guide and built a hackernews application in Dioxus. 
+
 To continue your journey, you can attempt a challenge listed below, or look at the [Dioxus reference](../reference/index.md).
 
 ## Challenges

--- a/docs-src/0.4/en/guide/state.md
+++ b/docs-src/0.4/en/guide/state.md
@@ -32,7 +32,7 @@ Let's create a [`onmouseenter`](https://docs.rs/dioxus/latest/dioxus/events/fn.o
 
 ## State
 
-So far our components have had no state like a normal rust functions. To make our application change when we hover over a link we need state to store the currently hovered link in the root of the application.
+So far our components have had no state like normal rust functions. To make our application change when we hover over a link we need state to store the currently hovered link in the root of the application.
 
 You can create state in dioxus using hooks. Hooks are Rust functions that take a reference to `ScopeState` (in a component, you can pass `cx`), and provide you with functionality and state.
 

--- a/src/doc_examples/hackernews_async.rs
+++ b/src/doc_examples/hackernews_async.rs
@@ -362,6 +362,7 @@ fn StoryListing(cx: Scope, story: StoryItem) -> Element {
         id,
         ..
     } = story;
+    // New
     let full_story = use_ref(cx, || None);
 
     let url = url.as_deref().unwrap_or_default();

--- a/src/doc_examples/hackernews_async.rs
+++ b/src/doc_examples/hackernews_async.rs
@@ -13,7 +13,7 @@ pub static USER_API: &str = "user/";
 const COMMENT_DEPTH: i64 = 2;
 
 pub async fn get_story_preview(id: i64) -> Result<StoryItem, reqwest::Error> {
-    let url = format!("{}item/{}.json", BASE_API_URL, id);
+    let url = format!("{}{}{}.json", BASE_API_URL, ITEM_API, id);
     reqwest::get(&url).await?.json().await
 }
 

--- a/src/doc_examples/hackernews_complete.rs
+++ b/src/doc_examples/hackernews_complete.rs
@@ -206,7 +206,7 @@ pub static USER_API: &str = "user/";
 const COMMENT_DEPTH: i64 = 2;
 
 pub async fn get_story_preview(id: i64) -> Result<StoryItem, reqwest::Error> {
-    let url = format!("{}item/{}.json", BASE_API_URL, id);
+    let url = format!("{}{}{}.json", BASE_API_URL, ITEM_API, id);
     reqwest::get(&url).await?.json().await
 }
 


### PR DESCRIPTION
This PR fixes minor typos and consistency issues with the example code within the Guide.