### PR TITLE
Adding axum-desktop documentation

### DIFF
--- a/docs-src/0.4/en/reference/fullstack/server_functions.md
+++ b/docs-src/0.4/en/reference/fullstack/server_functions.md
@@ -62,16 +62,16 @@ SandBoxFrame {
 
 ## Running the client with dioxus-desktop
 
-While the project presented so far makes a web browser interact with the server, it's possible to make a desktop program interact with the server in a similar fashion.
+The project presented so far makes a web browser interact with the server, but it is also possible to make a desktop program interact with the server in a similar fashion. (The full example code is available in the [Dioxus repo](https://github.com/DioxusLabs/dioxus/tree/master/packages/fullstack/examples/axum-desktop))
 
-As per the example on [Github](https://github.com/DioxusLabs/dioxus/tree/master/packages/fullstack/examples/axum-desktop), we need to make two binary targets, one for the desktop program (the `client.rs` file), one for the server (the `server.rs` file). The client app and the server functions are written in a common `lib.rs` file, shared by the two binaries.
+First, we need to make two binary targets, one for the desktop program (the `client.rs` file), one for the server (the `server.rs` file). The client app and the server functions are written in a shared `lib.rs` file.
 
-Each of the binary targets has a slightly different build configuration, as they include additional dependencies or features. 
-Have a look at the Cargo.toml for more information.
+The desktop and server targets have slightly different build configuration to enable additional dependencies or features. 
+The Cargo.toml in the full example has more information, but the main points are:
 - the client.rs has to be run with the `desktop` feature, so that the optional `dioxus-desktop` dependency is included
 - the server.rs has to be run with the `ssr` features; this will generate the server part of the server functions and will include the `axum` dependency to run as a server.
 
-This means you can run the server executable with:
+Once you create your project, you can run the server executable with:
 ```bash
 cargo run --bin server --features ssr
 ```
@@ -84,7 +84,7 @@ cargo run --bin client --features desktop
 
 The client file is pretty straightforward. You only need to set the server url in the client code, so it knows where to send the network requests. Then, dioxus_desktop launches the app.
 
-In order ot ease development, the example project sends requests to `localhost:8080` which is the address where the local server is run. Remember to set the correct url when you will run it in production.
+For development, the example project runs the server on `localhost:8080`. **Before you release remember to update the url to your production url.**
 
 
 ### Server code
@@ -94,8 +94,8 @@ In the server code, first you have to set the network address and port where the
 {{#include src/doc_examples/server_function_desktop_client.rs:server_url}}
 ```
 
-Afterwards, you have to register the types declared in the server function macros into the axum server.
-For instance, consider this server function:
+Then, you have to register the types declared in the server function macros into the axum server.
+For example, consider this server function:
 ```rust
 {{#include src/doc_examples/server_function_desktop_client.rs:server_function}}
 ```
@@ -105,4 +105,4 @@ The `GetServerData` type has to be registered in the axum server, which will add
 {{#include src/doc_examples/server_function_desktop_client.rs:function_registration}}
 ```
 
-Finally, the server is started and it begins serving data.
+Finally, the server is started and it begins responding to requests.

--- a/docs-src/0.4/en/reference/fullstack/server_functions.md
+++ b/docs-src/0.4/en/reference/fullstack/server_functions.md
@@ -58,3 +58,41 @@ SandBoxFrame {
 	url: "https://codesandbox.io/p/sandbox/dioxus-fullstack-server-future-qwpp4p?file=/src/main.rs:3,24"
 }
 ```
+
+
+## Running the client with dioxus-desktop
+
+While the project presented so far makes a web browser interact with the server, it's possible to make a desktop program interact with the server in a similar fashion.
+
+As per the example on [Github](https://github.com/DioxusLabs/dioxus/tree/master/packages/fullstack/examples/axum-desktop), we need to make two binary targets, one for the desktop program (the `client.rs` file), one for the server (the `server.rs` file). The client app and the server functions are written in a common `lib.rs` file, shared by the two binaries.
+
+Each of the binary targets has a slightly different build configuration, as they include additional dependencies or features.
+Have a look at the Cargo.toml for more information.
+- the client.rs has to be run with the `desktop` feature, so that the optional `dioxus-desktop` dependency is included
+- the server.rs has to be run with the `ssr` features; this will generate the server part of the server functions and will include the `axum` dependency to run as a server.
+
+### Client code
+
+The client file is pretty straightforward. You only need to set the server url in the client code, so it knows where to send the network requests. Then, dioxus_desktop launches the app.
+
+In order ot ease development, the example project sends requests to `localhost:8080` which is the address where the local server is run. Remember to set the correct url when you will run it in production.
+
+
+### Server code
+
+In the server code, first you have to set the network address where the server will listen to.
+
+Afterwards, you have to register the types declared in the server function macros into the axum server.
+For instance, consider this server function:
+```rust
+#[server(GetServerData)]
+async fn get_server_data() -> Result<String, ServerFnError> {
+    Ok("Hello from the server!".to_string())
+}
+```
+The `GetServerData` type has to be registered in the axum server, which will add the corresponding route to the server.
+```rust
+let _ = GetServerData::register_explicit();
+```
+
+Finally, the server is started and it begins serving data.

--- a/docs-src/0.4/en/reference/fullstack/server_functions.md
+++ b/docs-src/0.4/en/reference/fullstack/server_functions.md
@@ -90,6 +90,9 @@ In order ot ease development, the example project sends requests to `localhost:8
 ### Server code
 
 In the server code, first you have to set the network address and port where the server will listen to.
+```rust
+{{#include src/doc_examples/server_function_desktop_client.rs:server_url}}
+```
 
 Afterwards, you have to register the types declared in the server function macros into the axum server.
 For instance, consider this server function:

--- a/docs-src/0.4/en/reference/fullstack/server_functions.md
+++ b/docs-src/0.4/en/reference/fullstack/server_functions.md
@@ -66,10 +66,19 @@ While the project presented so far makes a web browser interact with the server,
 
 As per the example on [Github](https://github.com/DioxusLabs/dioxus/tree/master/packages/fullstack/examples/axum-desktop), we need to make two binary targets, one for the desktop program (the `client.rs` file), one for the server (the `server.rs` file). The client app and the server functions are written in a common `lib.rs` file, shared by the two binaries.
 
-Each of the binary targets has a slightly different build configuration, as they include additional dependencies or features.
+Each of the binary targets has a slightly different build configuration, as they include additional dependencies or features. 
 Have a look at the Cargo.toml for more information.
 - the client.rs has to be run with the `desktop` feature, so that the optional `dioxus-desktop` dependency is included
 - the server.rs has to be run with the `ssr` features; this will generate the server part of the server functions and will include the `axum` dependency to run as a server.
+
+This means you can run the server executable with:
+```bash
+cargo run --bin server --features ssr
+```
+and the client desktop executable with:
+```bash
+cargo run --bin client --features desktop
+```
 
 ### Client code
 
@@ -80,7 +89,7 @@ In order ot ease development, the example project sends requests to `localhost:8
 
 ### Server code
 
-In the server code, first you have to set the network address where the server will listen to.
+In the server code, first you have to set the network address and port where the server will listen to.
 
 Afterwards, you have to register the types declared in the server function macros into the axum server.
 For instance, consider this server function:

--- a/docs-src/0.4/en/reference/fullstack/server_functions.md
+++ b/docs-src/0.4/en/reference/fullstack/server_functions.md
@@ -85,14 +85,12 @@ In the server code, first you have to set the network address where the server w
 Afterwards, you have to register the types declared in the server function macros into the axum server.
 For instance, consider this server function:
 ```rust
-#[server(GetServerData)]
-async fn get_server_data() -> Result<String, ServerFnError> {
-    Ok("Hello from the server!".to_string())
-}
+{{#include src/doc_examples/server_function_desktop_client.rs:server_function}}
 ```
+
 The `GetServerData` type has to be registered in the axum server, which will add the corresponding route to the server.
 ```rust
-let _ = GetServerData::register_explicit();
+{{#include src/doc_examples/server_function_desktop_client.rs:function_registration}}
 ```
 
 Finally, the server is started and it begins serving data.

--- a/src/doc_examples/server_function_desktop_client.rs
+++ b/src/doc_examples/server_function_desktop_client.rs
@@ -14,7 +14,9 @@ use dioxus_fullstack::prelude::*;
 
 #[tokio::main]
 async fn main() {
+    // ANCHOR: server_url
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 8080));
+    // ANCHOR_END: server_url
 
     // ANCHOR: function_registration
     let _ = GetServerData::register_explicit();

--- a/src/doc_examples/server_function_desktop_client.rs
+++ b/src/doc_examples/server_function_desktop_client.rs
@@ -1,0 +1,31 @@
+#![allow(non_snake_case, unused)]
+use dioxus_fullstack::prelude::*;
+
+// ANCHOR: server_function
+#[server(GetServerData)]
+async fn get_server_data() -> Result<String, ServerFnError> {
+    Ok("Hello from the server!".to_string())
+}
+// ANCHOR_END: server_function
+
+
+use axum_desktop::*;
+use dioxus_fullstack::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 8080));
+
+    // ANCHOR: function_registration
+    let _ = GetServerData::register_explicit();
+    // ANCHOR_END: function_registration
+
+    axum::Server::bind(&addr)
+        .serve(
+            axum::Router::new()
+                .register_server_fns("")
+                .into_make_service(),
+        )
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
PR for issue #145 

Few notes:
- [x] for some reason I get a compile error when trying to run the docsite locally so I can't test if I broke something. I need to look into it
- [x] I'm trying to understand how the serverFn type registration works. Why the serverFn macro declares a new type? Is it only to be able to register the routes trough `register_explicit()` or do they have another use too?
- [x] I did put few lines of code in the markdown file. Do I have to create a separate file in `src/doc_examples` even if they're really short snippets?
- [x] I'm not a native English speaker so it might need some rephrasing