### PR TITLE
Update desktop examples

### DIFF
--- a/docs-src/0.4/en/getting_started/desktop.md
+++ b/docs-src/0.4/en/getting_started/desktop.md
@@ -12,7 +12,12 @@ Dioxus Desktop is built off [Tauri](https://tauri.app/). Right now there are lim
 
 # Examples
 
-Check out [cookbook/examples](../cookbook/examples.md) for more. Here's a [query](https://github.com/search?q=repo%3ADioxusLabs%2Fdioxus+path%3A%2F%5Eexamples%5C%2F%2F+%22use+dioxus_desktop%22&type=code) to find files which use `dioxus_desktop` (might not be 100% acurrate).
+- [File explorer](https://github.com/DioxusLabs/example-projects/blob/master/file-explorer)
+- [WiFi scanner](https://github.com/DioxusLabs/example-projects/blob/master/wifi-scanner)
+
+[![File explorer screenshot](https://raw.githubusercontent.com/DioxusLabs/example-projects/master/file-explorer/image.png)](https://github.com/DioxusLabs/example-projects/tree/master/file-explorer)
+
+Here's a [query](https://github.com/search?q=repo%3ADioxusLabs%2Fdioxus+path%3A%2F%5Eexamples%5C%2F%2F+%22use+dioxus_desktop%22&type=code) for the main repo to find examples which use `dioxus_desktop` (might not be 100% acurrate).
 
 # Getting started
 

--- a/docs-src/0.4/en/getting_started/desktop.md
+++ b/docs-src/0.4/en/getting_started/desktop.md
@@ -10,12 +10,9 @@ Dioxus Desktop is built off [Tauri](https://tauri.app/). Right now there are lim
 
 > In the future, we plan to move to a custom web renderer-based DOM renderer with WGPU integrations ([Blitz](https://github.com/DioxusLabs/blitz)).
 
-## Examples
+# Examples
 
-- [File Explorer](https://github.com/DioxusLabs/example-projects/blob/master/file-explorer)
-- [WiFi Scanner](https://github.com/DioxusLabs/example-projects/blob/master/wifi-scanner)
-
-[![File ExplorerExample](https://raw.githubusercontent.com/DioxusLabs/example-projects/master/file-explorer/image.png)](https://github.com/DioxusLabs/example-projects/tree/master/file-explorer)
+Check out [cookbook/examples](../cookbook/examples.md) for more. Here's a [query](https://github.com/search?q=repo%3ADioxusLabs%2Fdioxus+path%3A%2F%5Eexamples%5C%2F%2F+%22use+dioxus_desktop%22&type=code) to find files which use `dioxus_desktop` (might not be 100% acurrate).
 
 # Getting started
 

--- a/docs-src/0.4/en/getting_started/desktop.md
+++ b/docs-src/0.4/en/getting_started/desktop.md
@@ -10,12 +10,12 @@ Dioxus Desktop is built off [Tauri](https://tauri.app/). Right now there are lim
 
 > In the future, we plan to move to a custom web renderer-based DOM renderer with WGPU integrations ([Blitz](https://github.com/DioxusLabs/blitz)).
 
-# Examples
+## Examples
 
-- [File explorer](https://github.com/DioxusLabs/example-projects/blob/master/file-explorer)
-- [WiFi scanner](https://github.com/DioxusLabs/example-projects/blob/master/wifi-scanner)
+- [File Explorer](https://github.com/DioxusLabs/example-projects/blob/master/file-explorer)
+- [WiFi Scanner](https://github.com/DioxusLabs/example-projects/blob/master/wifi-scanner)
 
-[![File explorer screenshot](https://raw.githubusercontent.com/DioxusLabs/example-projects/master/file-explorer/image.png)](https://github.com/DioxusLabs/example-projects/tree/master/file-explorer)
+[![File Explorer screenshot](https://raw.githubusercontent.com/DioxusLabs/example-projects/master/file-explorer/image.png)](https://github.com/DioxusLabs/example-projects/tree/master/file-explorer)
 
 Here's a [query](https://github.com/search?q=repo%3ADioxusLabs%2Fdioxus+path%3A%2F%5Eexamples%5C%2F%2F+%22use+dioxus_desktop%22&type=code) for the main repo to find examples which use `dioxus_desktop` (might not be 100% acurrate).
 


### PR DESCRIPTION
- Removes the links to the sort-of-deprecated [example-projects repo](https://github.com/DioxusLabs/example-projects/).
- Adds a link to the `examples` directory.
- Adds a link to this GitHub search query: `repo:DioxusLabs/dioxus path:/^examples\// "use dioxus_desktop"`.