### PR TITLE
Document using windows_subsystem

### DIFF
--- a/docs-src/0.4/en/cookbook/publishing.md
+++ b/docs-src/0.4/en/cookbook/publishing.md
@@ -2,8 +2,7 @@
 
 After you have build your application, you will need to publish it somewhere. This reference will outline different methods of publishing your desktop or web application.
 
-## WEB: Publishing with Github Pages
-To build our app and publish it to Github:
+## Web: Publishing with GitHub Pages
 
 Edit your `Dioxus.toml` to point your `out_dir` to the `docs` folder and the `base_path` to the name of your repo:
 
@@ -24,7 +23,7 @@ dx build --release
 - Add and commit with git
 - Push to GitHub
 
-## DESKTOP: Creating an Installer
+## Desktop: Creating an installer
 
 Dioxus desktop app uses your operating system's WebView library, so it's portable to be distributed for other platforms.
 
@@ -48,7 +47,6 @@ And then your `main.rs`:
 
 ## Install `dioxus CLI`
 
-
 The first thing we'll do is install the [dioxus-cli](https://github.com/DioxusLabs/dioxus/tree/master/packages/cli). This extension to cargo will make it very easy to package our app for the various platforms.
 
 To install, simply run
@@ -57,11 +55,9 @@ To install, simply run
 
 ## Building
 
-To bundle your application you can simply run `dx bundle --release` to produce a final app with all the optimizations and assets builtin.
+To bundle your application you can simply run `dx bundle --release` (also add `--features bundle` if you're using that, see the [this](#preparing-your-application-for-bundling) for more) to produce a final app with all the optimizations and assets builtin.
 
-Once you've ran `dx bundle --release`, your app should be accessible in
-
-`dist/bundle/`.
+Once you've ran the command, your app should be accessible in `dist/bundle/`.
 
 For example, a macOS app would look like this:
 

--- a/docs-src/0.4/en/cookbook/publishing.md
+++ b/docs-src/0.4/en/cookbook/publishing.md
@@ -32,10 +32,18 @@ In this section, we'll cover how to bundle your app for macOS, Windows, and Linu
 
 ## Preparing your application for bundling
 
-Depending on your platform, you may need to add some additional code to your `main.rs` file to make sure your app is ready for bundling. On windows you'll need to add the `#![windows_subsystem = "windows"]` attribute to your `main.rs` file to hide the terminal window that pops up when you run your app.
+Depending on your platform, you may need to add some additional code to your `main.rs` file to make sure your app is ready for bundling. On Windows, you'll need to add the `#![windows_subsystem = "windows"]` attribute to your `main.rs` file to hide the terminal window that pops up when you run your app. **If you're developing on Windows, only use this when bundling.** It will disable the terminal, so you will not get logs of any kind. You can gate it behind a feature, like so:
+
+```toml
+# Cargo.toml
+[features]
+bundle = []
+```
+
+And then your `main.rs`:
 
 ```rust
-#![windows_subsystem = "windows"]
+#![cfg_attr(feature = "bundle", windows_subsystem = "windows")]
 ```
 
 ## Install `dioxus CLI`


### PR DESCRIPTION
Adds a disclaimer to only use it when bundling with an example of gating it behind a feature.