### PR TITLE
Fix docsite docs for tailwind

### DIFF
--- a/docs-src/0.4/en/cookbook/tailwind.md
+++ b/docs-src/0.4/en/cookbook/tailwind.md
@@ -141,10 +141,10 @@ One popular option for styling your Dioxus application is [Tailwind](https://tai
   dioxus_desktop::launch_cfg(
     App,
     dioxus_desktop::Config::new()
-      .with_custom_head(r#"<link rel="stylesheet" href="tailwind.css">"#.to_string()))
+      .with_custom_head(r#"<link rel="stylesheet" href="public/tailwind.css">"#.to_string()))
   ```
 - Launch the dioxus desktop app:
 
-    ```bash
-    cargo run
-    ```
+```bash
+cargo run
+```

--- a/docs-src/0.4/en/cookbook/tailwind.md
+++ b/docs-src/0.4/en/cookbook/tailwind.md
@@ -145,6 +145,6 @@ One popular option for styling your Dioxus application is [Tailwind](https://tai
   ```
 - Launch the dioxus desktop app:
 
-```bash
-cargo run
-```
+  ```bash
+  cargo run
+  ```


### PR DESCRIPTION
Change tailwind cookbook entry to fix desktop launch header, was pointing to the wrong path

[169](https://github.com/DioxusLabs/docsite/issues/169)

