### PR TITLE
Fix some outdated links in the Router guide and reference

### DIFF
--- a/docs-src/0.4/en/router/example/building-a-nest.md
+++ b/docs-src/0.4/en/router/example/building-a-nest.md
@@ -96,4 +96,4 @@ functionality to build the blog portion of our application. In the next chapter,
 we will go over how navigation targets (like the one we passed to our links)
 work.
 
-[`Link`]: https://docs.rs/dioxus-router/latest/dioxus_router/prelude/fn.GenericLink<R>.html
+[`Link`]: https://docs.rs/dioxus-router/latest/dioxus_router/components/fn.Link.html

--- a/docs-src/0.4/en/router/example/index.md
+++ b/docs-src/0.4/en/router/example/index.md
@@ -5,7 +5,7 @@ building a small todo app or the next FAANG company. We will create a small
 website with a blog, homepage, and more!
 
 > To follow along with the router example, you'll need a working Dioxus app.
-> Check out the [Dioxus book](http://localhost:8080/learn/0.4/getting_started) to get started.
+> Check out the [Dioxus book](https://dioxuslabs.com/learn/0.4/getting_started) to get started.
 
 > Make sure to add Dioxus Router as a dependency, as explained in the
 > [introduction](../index.md).

--- a/docs-src/0.4/en/router/example/index.md
+++ b/docs-src/0.4/en/router/example/index.md
@@ -5,7 +5,7 @@ building a small todo app or the next FAANG company. We will create a small
 website with a blog, homepage, and more!
 
 > To follow along with the router example, you'll need a working Dioxus app.
-> Check out the [Dioxus book](https://dioxuslabs.com/docs/0.3/guide/en/) to get started.
+> Check out the [Dioxus book](http://localhost:8080/learn/0.4/getting_started) to get started.
 
 > Make sure to add Dioxus Router as a dependency, as explained in the
 > [introduction](../index.md).

--- a/docs-src/0.4/en/router/example/navigation-targets.md
+++ b/docs-src/0.4/en/router/example/navigation-targets.md
@@ -22,6 +22,6 @@ If we need a link to an external page we can do it like this:
 {{#include src/doc_examples/external_link.rs:component}}
 ```
 
-[`External`]: https://docs.rs/dioxus-router-core/latest/dioxus_router/navigation/enum.NavigationTarget.html#variant.External
-[`Internal`]: https://docs.rs/dioxus-router-core/latest/dioxus_router/navigation/enum.NavigationTarget.html#variant.Internal
-[`NavigationTarget`]: https://docs.rs/dioxus-router-core/latest/dioxus_router/navigation/enum.NavigationTarget.html
+[`External`]: https://docs.rs/dioxus-router/latest/dioxus_router/navigation/enum.NavigationTarget.html#variant.External
+[`Internal`]: https://docs.rs/dioxus-router/latest/dioxus_router/navigation/enum.NavigationTarget.html#variant.Internal
+[`NavigationTarget`]: https://docs.rs/dioxus-router/latest/dioxus_router/navigation/enum.NavigationTarget.html

--- a/docs-src/0.4/en/router/index.md
+++ b/docs-src/0.4/en/router/index.md
@@ -10,7 +10,7 @@ For this purpose, Dioxus provides a router. Use the `cargo add` command to add t
 cargo add dioxus-router
 ```
 
-Then, add this to your `Dioxus.toml` (learn more about configuration [here](https://dioxuslabs.com/learn/0.4/CLI/configure)):
+Then, add this to your `Dioxus.toml` (learn more about configuration [here](../CLI/configure)):
 
 ```toml
 [web.watcher]

--- a/docs-src/0.4/en/router/reference/routes/nested.md
+++ b/docs-src/0.4/en/router/reference/routes/nested.md
@@ -27,8 +27,8 @@ To nest routes, we use the `#[nest("path")]` and `#[end_nest]` attributes.
 
 The path in nest must not:
 
-1. Contain a [Catch All Segment](./index.md#catch-all-segments)
-2. Contain a [Query Segment](./index.md#query-segments)
+1. Contain a [Catch All Segment](./#catch-all-segments)
+2. Contain a [Query Segment](./#query-segments)
 
 If you define a dynamic segment in a nest, it will be available to all child routes and layouts.
 

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -1,5 +1,5 @@
 /*
-! tailwindcss v3.3.3 | MIT License | https://tailwindcss.com
+! tailwindcss v3.3.2 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -191,10 +191,6 @@ select,
 textarea {
   font-family: inherit;
   /* 1 */
-  font-feature-settings: inherit;
-  /* 1 */
-  font-variation-settings: inherit;
-  /* 1 */
   font-size: 100%;
   /* 1 */
   font-weight: inherit;
@@ -342,14 +338,6 @@ ul,
 menu {
   list-style: none;
   margin: 0;
-  padding: 0;
-}
-
-/*
-Reset default styling for dialogs.
-*/
-
-dialog {
   padding: 0;
 }
 
@@ -1650,10 +1638,6 @@ video {
   padding-bottom: 1rem;
 }
 
-.pb-48 {
-  padding-bottom: 12rem;
-}
-
 .pb-64 {
   padding-bottom: 16rem;
 }
@@ -2792,7 +2776,7 @@ video {
   }
 }
 
-@media(min-height:1080px) {
+@media (min-height:1080px) {
   .\[\@media\(min-height\:1080px\)\]\:h-screen {
     height: 100vh;
   }


### PR DESCRIPTION
This PR addresses #174.

Some of the links (as in the urls and not the Link component) are outdated so I fixed what I was able to find while reading the guide. I also changed one absolute link (to CLI config) into a relative link; that should open up the local copy when running the site locally. Plus, some links to the a page's internal links are broken, so I've some of that as well.