### PR TITLE
Fix the accept attribute in the file upload examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ use-mdbook = { git = "https://github.com/dioxuslabs/include_mdbook" }
 dioxus-search = { git = "https://github.com/dioxuslabs/dioxus-search" }
 
 tokio = { version = "1.29.0", features = ["full"], optional = true }
-axum = { version = "0.6.12", optional = true }
+axum = { version = "0.6.12", features = ["headers"], optional = true }
 simple_logger = "4.2.0"
 shipyard = { version = "0.6.2", optional = true }
 reqwest = { version = "0.11.18", features = ["json"] }
@@ -63,6 +63,11 @@ pretty_assertions = { version = "1.4.0", optional = true }
 gloo-timers = { version = "0.2.6", features = ["futures"] }
 js-sys = "0.3.64"
 form_urlencoded = "1.2.0"
+automod = "1.0.13"
+
+# Used only in doc tests
+dioxus-std = { version = "0.4.1", features = ["i18n"], optional = true }
+tower-http = { version = "0.4.0", optional = true, features = ["timeout"] }
 
 [profile.release]
 # lto = true
@@ -93,6 +98,8 @@ doc_test = [
     "shipyard",
     "gloo-storage",
     "pretty_assertions",
+    "tower-http",
+    "dioxus-std",
 ]
 web = ["dioxus-web", "dioxus-router/web"]
 ssr = [

--- a/docs-src/0.4/en/getting_started/wasm.md
+++ b/docs-src/0.4/en/getting_started/wasm.md
@@ -66,7 +66,7 @@ If you open the browser and navigate to `127.0.0.1` you should see an app that l
 
 ```inject-dioxus
 DemoFrame {
-    HelloWorldCounter {}
+    hello_world::HelloWorldCounter {}
 }
 ```
 

--- a/docs-src/0.4/en/reference/rsx.md
+++ b/docs-src/0.4/en/reference/rsx.md
@@ -20,7 +20,7 @@ RSX is very similar to HTML in that it describes elements with attributes and ch
 
 ```inject-dioxus
 DemoFrame {
-	Empty {}
+	rsx_overview::Empty {}
 }
 ```
 
@@ -34,7 +34,7 @@ Attributes (and [event handlers](event_handlers.md)) modify the behavior or appe
 
 ```inject-dioxus
 DemoFrame {
-	Attributes {}
+	rsx_overview::Attributes {}
 }
 ```
 
@@ -52,7 +52,7 @@ Dioxus has a pre-configured set of attributes that you can use. RSX is validated
 
 ```inject-dioxus
 DemoFrame {
-	CustomAttributes {}
+	rsx_overview::CustomAttributes {}
 }
 ```
 
@@ -136,7 +136,7 @@ Similarly to how you can [format](https://doc.rust-lang.org/rust-by-example/hell
 
 ```inject-dioxus
 DemoFrame {
-	Formatting {}
+	rsx_overview::Formatting {}
 }
 ```
 
@@ -150,7 +150,7 @@ To add children to an element, put them inside the `{}` brackets after all attri
 
 ```inject-dioxus
 DemoFrame {
-	Children {}
+	rsx_overview::Children {}
 }
 ```
 
@@ -164,7 +164,7 @@ You can render multiple elements at the top level of `rsx!` and they will be aut
 
 ```inject-dioxus
 DemoFrame {
-	ManyRoots {}
+	rsx_overview::ManyRoots {}
 }
 ```
 
@@ -178,7 +178,7 @@ You can include arbitrary Rust expressions as children within RSX that implement
 
 ```inject-dioxus
 DemoFrame {
-	Expression {}
+	rsx_overview::Expression {}
 }
 ```
 
@@ -192,7 +192,7 @@ In addition to iterators you can also use for loops directly within RSX:
 
 ```inject-dioxus
 DemoFrame {
-	Loops {}
+	rsx_overview::Loops {}
 }
 ```
 
@@ -206,6 +206,6 @@ You can also use if statements without an else branch within RSX:
 
 ```inject-dioxus
 DemoFrame {
-	IfStatements {}
+	rsx_overview::IfStatements {}
 }
 ```

--- a/src/doc_examples/input_fileengine.rs
+++ b/src/doc_examples/input_fileengine.rs
@@ -13,10 +13,10 @@ pub fn App(cx: Scope) -> Element {
             accept: ".txt,.rs",
             // pick multiple files
             multiple: true,
-            onchange: |evt| {
+            onchange: move |evt| {
                 if let Some(file_engine) = &evt.files {
                     let files = file_engine.files();
-                    for file_name in &files {
+                    for file_name in files {
                         filenames.write().push(file_name);
                     }
                 }

--- a/src/doc_examples/input_fileengine.rs
+++ b/src/doc_examples/input_fileengine.rs
@@ -10,7 +10,7 @@ pub fn App(cx: Scope) -> Element {
             // tell the input to pick a file
             r#type:"file",
             // list the accepted extensions
-            accept: ".txt, .rs",
+            accept: ".txt,.rs",
             // pick multiple files
             multiple: true,
             onchange: |evt| {

--- a/src/doc_examples/input_fileengine_async.rs
+++ b/src/doc_examples/input_fileengine_async.rs
@@ -11,7 +11,7 @@ pub fn App(cx: Scope) -> Element {
             accept: ".txt,.rs",
             multiple: true,
             // ANCHOR: onchange_event
-            onchange: |evt| {
+            onchange: move |evt| {
                 // A helper macro to use hooks in async environments
                 to_owned![files_uploaded];
                 async move {

--- a/src/doc_examples/input_fileengine_async.rs
+++ b/src/doc_examples/input_fileengine_async.rs
@@ -8,7 +8,7 @@ pub fn App(cx: Scope) -> Element {
     cx.render(rsx! {
         input {
             r#type:"file",
-            accept: ".txt, .rs",
+            accept: ".txt,.rs",
             multiple: true,
             // ANCHOR: onchange_event
             onchange: |evt| {

--- a/src/doc_examples/input_fileengine_folder.rs
+++ b/src/doc_examples/input_fileengine_folder.rs
@@ -13,7 +13,7 @@ pub fn App(cx: Scope) -> Element {
             onchange: |evt| {
                 if let Some(file_engine) = &evt.files {
                     let files = file_engine.files();
-                    for file_name in &files {
+                    for file_name in files {
                         println!("{}", file_name);
                         // Do something with the folder path
                     }

--- a/src/doc_examples/mod.rs
+++ b/src/doc_examples/mod.rs
@@ -30,15 +30,15 @@ pub mod hackernews_post;
 #[cfg(not(feature = "doc_test"))]
 pub mod hackernews_state;
 #[cfg(not(feature = "doc_test"))]
-pub mod hooks_out_of_date;
-#[cfg(not(feature = "doc_test"))]
-pub mod hooks_use_ref;
+pub mod hello_world;
 #[cfg(not(feature = "doc_test"))]
 pub mod hooks_counter;
 #[cfg(not(feature = "doc_test"))]
-pub mod rsx_overview;
-#[cfg(not(feature = "doc_test"))]
 pub mod hooks_counter_two_state;
+#[cfg(not(feature = "doc_test"))]
+pub mod hooks_out_of_date;
+#[cfg(not(feature = "doc_test"))]
+pub mod hooks_use_ref;
 #[cfg(not(feature = "doc_test"))]
 pub mod input_controlled;
 #[cfg(not(feature = "doc_test"))]
@@ -48,13 +48,12 @@ pub mod readme;
 #[cfg(not(feature = "doc_test"))]
 pub mod rendering_lists;
 #[cfg(not(feature = "doc_test"))]
+pub mod rsx_overview;
+#[cfg(not(feature = "doc_test"))]
 pub mod spawn;
 #[cfg(not(feature = "doc_test"))]
 pub mod use_future;
-#[cfg(not(feature = "doc_test"))]
-pub mod hello_world;
 
 // Check any examples we don't compile into the docs
 #[cfg(feature = "doc_test")]
 automod::dir!(pub "src/doc_examples");
-

--- a/src/doc_examples/mod.rs
+++ b/src/doc_examples/mod.rs
@@ -1,128 +1,60 @@
 #![allow(unused)]
 
-#[cfg(feature = "doc_test")]
-mod anti_patterns;
+// Include any examples we compile into the docsite
+#[cfg(not(feature = "doc_test"))]
 pub mod boolean_attribute;
-#[cfg(feature = "doc_test")]
-mod catch_all;
-#[cfg(feature = "doc_test")]
-mod catch_all_segments;
+#[cfg(not(feature = "doc_test"))]
 pub mod component_borrowed_props;
+#[cfg(not(feature = "doc_test"))]
 pub mod component_children;
-#[cfg(feature = "doc_test")]
-mod component_children_inspect;
-#[cfg(feature = "doc_test")]
-mod component_element_props;
+#[cfg(not(feature = "doc_test"))]
 pub mod component_owned_props;
-#[cfg(feature = "doc_test")]
-mod component_props_options;
-#[cfg(feature = "doc_test")]
-mod component_test;
+#[cfg(not(feature = "doc_test"))]
 pub mod components;
+#[cfg(not(feature = "doc_test"))]
 pub mod conditional_rendering;
-#[cfg(feature = "doc_test")]
-mod custom_assets;
-#[cfg(feature = "doc_test")]
-mod custom_renderer;
+#[cfg(not(feature = "doc_test"))]
 pub mod dangerous_inner_html;
-#[cfg(feature = "doc_test")]
-mod dynamic_route;
-#[cfg(feature = "doc_test")]
-mod dynamic_segments;
-#[cfg(feature = "doc_test")]
-mod eval;
+#[cfg(not(feature = "doc_test"))]
 pub mod event_click;
-#[cfg(feature = "doc_test")]
-mod event_handler_prop;
-#[cfg(feature = "doc_test")]
-mod event_nested;
+#[cfg(not(feature = "doc_test"))]
 pub mod event_prevent_default;
-#[cfg(feature = "doc_test")]
-mod external_link;
-#[cfg(feature = "doc_test")]
-mod first_route;
+#[cfg(not(feature = "doc_test"))]
 pub mod full_example;
+#[cfg(not(feature = "doc_test"))]
 pub mod hackernews_async;
+#[cfg(not(feature = "doc_test"))]
 pub mod hackernews_complete;
+#[cfg(not(feature = "doc_test"))]
 pub mod hackernews_post;
+#[cfg(not(feature = "doc_test"))]
 pub mod hackernews_state;
-mod hello_world;
-#[cfg(feature = "doc_test")]
-mod hello_world_desktop;
-#[cfg(feature = "doc_test")]
-mod hello_world_liveview;
-#[cfg(feature = "doc_test")]
-mod hello_world_ssr;
-#[cfg(feature = "doc_test")]
-mod hello_world_tui;
-#[cfg(feature = "doc_test")]
-mod hello_world_tui_no_ctrl_c;
-#[cfg(feature = "doc_test")]
-mod hello_world_web;
-#[cfg(feature = "doc_test")]
-mod hook_test;
-#[cfg(feature = "doc_test")]
-mod server_data_fetch;
-#[cfg(feature = "doc_test")]
-mod server_data_prefetch;
-#[cfg(feature = "doc_test")]
-mod use_coroutine_reference;
-pub use hello_world::*;
-#[cfg(feature = "doc_test")]
-mod history_buttons;
-#[cfg(feature = "doc_test")]
-mod history_provider;
-#[cfg(feature = "doc_test")]
-mod hooks_anti_patterns;
-#[cfg(feature = "doc_test")]
-mod hooks_bad;
-#[cfg(feature = "doc_test")]
-mod hooks_composed;
-pub mod hooks_counter;
-pub mod hooks_counter_two_state;
-#[cfg(feature = "doc_test")]
-mod hooks_custom_logic;
+#[cfg(not(feature = "doc_test"))]
 pub mod hooks_out_of_date;
+#[cfg(not(feature = "doc_test"))]
 pub mod hooks_use_ref;
-#[cfg(feature = "doc_test")]
-mod hydration;
+#[cfg(not(feature = "doc_test"))]
+pub mod hooks_counter;
+#[cfg(not(feature = "doc_test"))]
+pub mod rsx_overview;
+#[cfg(not(feature = "doc_test"))]
+pub mod hooks_counter_two_state;
+#[cfg(not(feature = "doc_test"))]
 pub mod input_controlled;
+#[cfg(not(feature = "doc_test"))]
 pub mod input_uncontrolled;
-#[cfg(feature = "doc_test")]
-mod links;
-#[cfg(feature = "doc_test")]
-mod meme_editor;
-#[cfg(feature = "doc_test")]
-mod meme_editor_dark_mode;
-#[cfg(feature = "doc_test")]
-mod navigator;
-#[cfg(feature = "doc_test")]
-mod nest;
-#[cfg(feature = "doc_test")]
-mod nested_routes;
-#[cfg(feature = "doc_test")]
-mod outlet;
-#[cfg(feature = "doc_test")]
-mod query_segments;
+#[cfg(not(feature = "doc_test"))]
 pub mod readme;
-#[cfg(feature = "doc_test")]
-mod readme_expanded;
+#[cfg(not(feature = "doc_test"))]
 pub mod rendering_lists;
-#[cfg(feature = "doc_test")]
-mod router_cfg;
-#[cfg(feature = "doc_test")]
-mod routing_update;
-mod rsx_overview;
-#[cfg(feature = "doc_test")]
-mod server_router;
-#[cfg(feature = "doc_test")]
-mod use_coroutine;
-pub use rsx_overview::*;
-#[cfg(feature = "doc_test")]
-mod server_basic;
-#[cfg(feature = "doc_test")]
-mod server_function;
+#[cfg(not(feature = "doc_test"))]
 pub mod spawn;
-#[cfg(feature = "doc_test")]
-mod static_segments;
+#[cfg(not(feature = "doc_test"))]
 pub mod use_future;
+#[cfg(not(feature = "doc_test"))]
+pub mod hello_world;
+
+// Check any examples we don't compile into the docs
+#[cfg(feature = "doc_test")]
+automod::dir!(pub "src/doc_examples");
+

--- a/src/doc_examples/server_function_desktop_client.rs
+++ b/src/doc_examples/server_function_desktop_client.rs
@@ -9,7 +9,6 @@ async fn get_server_data() -> Result<String, ServerFnError> {
 // ANCHOR_END: server_function
 
 
-use axum_desktop::*;
 use dioxus_fullstack::prelude::*;
 
 #[tokio::main]


### PR DESCRIPTION
The file upload examples include an extra space between the two extension options, but the accept attribute does not allow extra whitespace. This PR removes that extra space to fix the example