### PR TITLE
Fix:  mobile docs - remove logging + desktop_config

### DIFF
--- a/docs-src/0.4/en/getting_started/mobile.md
+++ b/docs-src/0.4/en/getting_started/mobile.md
@@ -109,8 +109,6 @@ Finally, we need to add a component to renderer. Modify your main function:
 use dioxus::prelude::*;
 
 pub fn main() -> Result<()> {
-    // init_logging();
-
     // Right now we're going through dioxus-desktop but we'd like to go through dioxus-mobile
     // That will seed the index.html with some fixes that prevent the page from scrolling/zooming etc
     dioxus_desktop::launch_cfg(

--- a/docs-src/0.4/en/getting_started/mobile.md
+++ b/docs-src/0.4/en/getting_started/mobile.md
@@ -109,7 +109,7 @@ Finally, we need to add a component to renderer. Modify your main function:
 use dioxus::prelude::*;
 
 pub fn main() -> Result<()> {
-    init_logging();
+    // init_logging();
 
     // Right now we're going through dioxus-desktop but we'd like to go through dioxus-mobile
     // That will seed the index.html with some fixes that prevent the page from scrolling/zooming etc
@@ -117,7 +117,7 @@ pub fn main() -> Result<()> {
         app,
         // Note that we have to disable the viewport goofiness of the browser.
         // Dioxus_mobile should do this for us
-        Config::default().with_custom_index(r#"<!DOCTYPE html>
+        dioxus_desktop::Config::default().with_custom_index(r#"<!DOCTYPE html>
         <html>
           <head>
             <title>Dioxus app</title>


### PR DESCRIPTION
Hi there, I tried running the mobile example and hit a few snags.

`init_logging` is not defined by default, I commented in this PR, maybe adding a simple init_logging fn is desirable (to make it harmonious across iOS and Android). 
`Config` is also not in the prelude therefore I think `dioxus_desktop::Config` is necessary.

