### PR TITLE
Fix the android getting started guide

### DIFF
--- a/docs-src/0.4/en/getting_started/mobile.md
+++ b/docs-src/0.4/en/getting_started/mobile.md
@@ -99,14 +99,14 @@ Next, we need to modify our dependencies to include dioxus and ensure the right 
 
 ```toml
 [dependencies]
-anyhow = "1.0.56"
+anyhow = "1.0.56"br
 log = "0.4.11"
-dioxus = { git = "https://github.com/ealmloff/dioxus", branch = "bump-wry", version = "0.4.2" }
-dioxus-desktop = { git = "https://github.com/ealmloff/dioxus", branch = "bump-wry", version = "0.4.2", default-features = false, features = ["tokio_runtime"] }
+dioxus = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.2" }
+dioxus-desktop = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.2", default-features = false, features = ["tokio_runtime"] }
 wry = "0.34.0"
 ```
 
-> Note: There is a bug in the older version of wry that is used by default in cargo-mobile2 and dioxus. We need to use the latest version of wry and an unpublished branch of dioxus that uses the latest version of wry. This will be fixed in the future. See [this issue](https://github.com/DioxusLabs/dioxus/issues/1158) for more details.
+> Note: There is a bug in the older version of wry that is used by default in cargo-mobile2 and dioxus. We need to use the latest version of wry and the unpublished version of dioxus that uses the latest version of wry. This will be fixed in the future. See [this issue](https://github.com/DioxusLabs/dioxus/issues/1158) for more details.
 
 Finally, we need to add a component to renderer. Replace the main function in your `lib.rs` file with this code:
 

--- a/docs-src/0.4/en/getting_started/mobile.md
+++ b/docs-src/0.4/en/getting_started/mobile.md
@@ -99,7 +99,7 @@ Next, we need to modify our dependencies to include dioxus and ensure the right 
 
 ```toml
 [dependencies]
-anyhow = "1.0.56"br
+anyhow = "1.0.56"
 log = "0.4.11"
 dioxus = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.2" }
 dioxus-desktop = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.2", default-features = false, features = ["tokio_runtime"] }

--- a/docs-src/0.4/en/getting_started/mobile.md
+++ b/docs-src/0.4/en/getting_started/mobile.md
@@ -93,7 +93,7 @@ cargo mobile init
 
 When you run `cargo mobile init`, you will be asked a series of questions about your project. One of those questions is what template you should use. Dioxus currently doesn't have a template in Tauri mobile, instead you can use the `wry` template.
 
-> You may also be asked to input your team ID for IOS. You can find your team id [here](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/) or create a team id by creating a developer account [here](https://developer.apple.com/help/account/get-started/about-your-developer-account)
+> You may also be asked to input your team ID for IOS. You can find your team id [here](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/) or create a team id by creating a develwr; oper account [here](https://developer.apple.com/help/account/get-started/about-your-developer-account)
 
 Next, we need to modify our dependencies to include dioxus and ensure the right version of wry is installed. Change the `[dependencies]` section of your `Cargo.toml`:
 
@@ -103,7 +103,7 @@ anyhow = "1.0.56"
 log = "0.4.11"
 dioxus = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.2" }
 dioxus-desktop = { git = "https://github.com/dioxuslabs/dioxus", version = "0.4.2", default-features = false, features = ["tokio_runtime"] }
-wry = "0.34.0"
+wry = "0.35.0"
 ```
 
 > Note: There is a bug in the older version of wry that is used by default in cargo-mobile2 and dioxus. We need to use the latest version of wry and the unpublished version of dioxus that uses the latest version of wry. This will be fixed in the future. See [this issue](https://github.com/DioxusLabs/dioxus/issues/1158) for more details.

--- a/docs-src/0.4/en/getting_started/mobile.md
+++ b/docs-src/0.4/en/getting_started/mobile.md
@@ -150,7 +150,9 @@ fn app(cx: Scope) -> Element {
                 button {
                     onclick: move|_| {
                         println!("Clicked!");
-                        items.write().push(0);
+                        let mut items_mut = items.write();
+                        let new_item = items_mut.len() + 1;
+                        items_mut.push(new_item);
                         println!("Requested update");
                     },
                     "Add item"
@@ -250,7 +252,9 @@ fn app(cx: Scope) -> Element {
                 button {
                     onclick: move|_| {
                         println!("Clicked!");
-                        items.write().push(0);
+                        let mut items_mut = items.write();
+                        let new_item = items_mut.len() + 1;
+                        items_mut.push(new_item);
                         println!("Requested update");
                     },
                     "Add item"


### PR DESCRIPTION
This fixes two issues with the android guide for dioxus along with some formatting issues:

1) It points users to a fork of dioxus that fixes https://github.com/DioxusLabs/dioxus/issues/1158 instead of the main branch until 0.5 is published
2) It removes the extra `main.rs` file that is generated by `cargo new` which can make it unclear which `fn main(){}` you should change