### PR TITLE
Formatting fixes in CLI section of docs

### DIFF
--- a/docs-src/0.4/en/CLI/configure.md
+++ b/docs-src/0.4/en/CLI/configure.md
@@ -1,13 +1,8 @@
 # Configure Project
 
-This chapter will teach you how to configure the CLI with the `Dioxus.toml` file.
-There's an [example](#config-example) which has comments to describe individual keys.
-You can copy that or view this documentation for a more complete learning experience.
+This chapter will teach you how to configure the CLI with the `Dioxus.toml` file. There's an [example](#config-example) which has comments to describe individual keys. You can copy that or view this documentation for a more complete learning experience.
 
-"🔒" indicates a mandatory item.
-Some headers are mandatory, but none of the keys inside them are.
-In that case, you only need to include the header, but no keys.
-It might look weird, but it's normal.
+"🔒" indicates a mandatory item. Some headers are mandatory, but none of the keys inside them are. In that case, you only need to include the header, but no keys. It might look weird, but it's normal.
 
 ## Structure
 
@@ -80,9 +75,7 @@ Development server configuration.
    ```
 
 * **index_on_404** - If enabled, Dioxus will serve the root page when a route is not found.
-   *This is needed when serving an application that uses the router*.
-   However, when serving your app using something else than Dioxus (e.g. GitHub Pages), you will have to check how to configure it on that platform.
-   In GitHub Pages, you can make a copy of `index.html` named `404.html` in the same directory.
+   *This is needed when serving an application that uses the router*. However, when serving your app using something else than Dioxus (e.g. GitHub Pages), you will have to check how to configure it on that platform. In GitHub Pages, you can make a copy of `index.html` named `404.html` in the same directory.
    ```toml
    index_on_404 = true
    ```
@@ -121,8 +114,7 @@ Static resource configuration.
 [web.resource.dev]
 ```
 
-This is the same as [`[web.resource]`](#webresource-), but it only works in development servers.
-For example, if you want to include a file in a `dx serve` server, but not a `dx serve --release` server, put it here.
+This is the same as [`[web.resource]`](#webresource-), but it only works in development servers. For example, if you want to include a file in a `dx serve` server, but not a `dx serve --release` server, put it here.
 
 ### Web.Proxy
 

--- a/docs-src/0.4/en/CLI/creating.md
+++ b/docs-src/0.4/en/CLI/creating.md
@@ -21,5 +21,4 @@ Next, navigate into your new project using `cd project-name`, or simply opening 
 > rustup target add wasm32-unknown-unknown
 > ```
 
-Finally, serve your project with `dx serve`!
-The CLI will tell you the address it is serving on, along with additional info such as code warnings.
+Finally, serve your project with `dx serve`! The CLI will tell you the address it is serving on, along with additional info such as code warnings.

--- a/docs-src/0.4/en/CLI/index.md
+++ b/docs-src/0.4/en/CLI/index.md
@@ -2,9 +2,7 @@
 
 The ✨**Dioxus CLI**✨ is a tool to get Dioxus projects off the ground.
 
-There's no documentation for commands here,
-but you can see all commands using `dx --help` once you've installed the CLI!
-Furthermore, you can run `dx <command> --help` to get help with a specific command.
+There's no documentation for commands here, but you can see all commands using `dx --help` once you've installed the CLI! Furthermore, you can run `dx <command> --help` to get help with a specific command.
 
 ## Features
 

--- a/docs-src/0.4/en/CLI/installation.md
+++ b/docs-src/0.4/en/CLI/installation.md
@@ -10,16 +10,12 @@ If you get an OpenSSL error on installation, ensure the dependencies listed [her
 
 ## Install the latest development build through git
 
-To get the latest bug fixes and features, you can install the development version from git.
-However, this is not fully tested.
-That means you're probably going to have more bugs despite having the latest bug fixes.
+To get the latest bug fixes and features, you can install the development version from git. However, this is not fully tested. That means you're probably going to have more bugs despite having the latest bug fixes.
 
 ```
 cargo install --git https://github.com/DioxusLabs/dioxus dioxus-cli
 ```
 
-This will download the CLI from the master branch,
-and install it in Cargo's global binary directory (`~/.cargo/bin/` by default).
+This will download the CLI from the master branch, and install it in Cargo's global binary directory (`~/.cargo/bin/` by default).
 
-Run `dx --help` for a list of all the available commands.
-Furthermore, you can run `dx <command> --help` to get help with a specific command.
+Run `dx --help` for a list of all the available commands. Furthermore, you can run `dx <command> --help` to get help with a specific command.


### PR DESCRIPTION
Noticed a few places that were missing spaces between sentences or after punctuation, this PR changes newlines that aren't correctly recognized by the parser into spaces in noticed documents.