### PR TITLE
Change path to tailwind.css for desktop application

### DIFF
--- a/docs-src/0.4/en/cookbook/tailwind.md
+++ b/docs-src/0.4/en/cookbook/tailwind.md
@@ -141,7 +141,7 @@ One popular option for styling your Dioxus application is [Tailwind](https://tai
   dioxus_desktop::launch_cfg(
     App,
     dioxus_desktop::Config::new()
-      .with_custom_head(r#"<link rel="stylesheet" href="public/tailwind.css">"#.to_string()))
+      .with_custom_head(r#"<link rel="stylesheet" href="tailwind.css">"#.to_string()))
   ```
 - Launch the dioxus desktop app:
 


### PR DESCRIPTION
This change make it possible to load `tailwind.css` file in desktop version of application. Before change, file was searched for `public` directory which does not exists in `dist` folder.