### PR TITLE
Address Issue #208 installation instructions for dioxus cli in tailwind.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ changes you can install the [`dx`][dx] tool locally, assuming you already have a
 working `Rust` setup:
 
 ```sh
-cargo install dioxus-cli
+cargo install dioxus-cli@0.5.0-alpha.0
 ```
 
 With [`dx`][dx] installed, you can use it to build and serve the documentation

--- a/docs-src/0.5/en/CLI/installation.md
+++ b/docs-src/0.5/en/CLI/installation.md
@@ -3,7 +3,7 @@
 ## Install the stable version (recommended)
 
 ```
-cargo install dioxus-cli
+cargo install dioxus-cli@0.5.0-alpha.0
 ```
 
 If you get an OpenSSL error on installation, ensure the dependencies listed [here](https://docs.rs/openssl/latest/openssl/#automatic) are installed.

--- a/docs-src/0.5/en/cookbook/publishing.md
+++ b/docs-src/0.5/en/cookbook/publishing.md
@@ -54,7 +54,7 @@ The first thing we'll do is install the [dioxus-cli](https://github.com/DioxusLa
 
 To install, simply run
 
-`cargo install dioxus-cli`
+`cargo install dioxus-cli@0.5.0-alpha.0`
 
 ## Building
 

--- a/docs-src/0.5/en/cookbook/tailwind.md
+++ b/docs-src/0.5/en/cookbook/tailwind.md
@@ -10,7 +10,7 @@ One popular option for styling your Dioxus application is [Tailwind](https://tai
 1. Install the Dioxus CLI:
 
 ```bash
-cargo install --git https://github.com/DioxusLabs/cli
+cargo install dioxus-cli
 ```
 
 2. Install npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

--- a/docs-src/0.5/en/cookbook/tailwind.md
+++ b/docs-src/0.5/en/cookbook/tailwind.md
@@ -52,10 +52,10 @@ module.exports = {
 7. Add [Manganis](https://github.com/DioxusLabs/collect-assets) to your project to handle asset collection.
 
 ```sh
-cargo add maganis
+cargo add manganis
 ```
 
-8. Create a link to the `tailwind.css` file using maganis somewhere in your rust code:
+8. Create a link to the `tailwind.css` file using manganis somewhere in your rust code:
 
 ```rust
 {{#include src/doc_examples/tailwind.rs}}

--- a/docs-src/0.5/en/cookbook/tailwind.md
+++ b/docs-src/0.5/en/cookbook/tailwind.md
@@ -10,7 +10,7 @@ One popular option for styling your Dioxus application is [Tailwind](https://tai
 1. Install the Dioxus CLI:
 
 ```bash
-cargo install dioxus-cli
+cargo install dioxus-cli@0.5.0-alpha.0
 ```
 
 2. Install npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

--- a/docs-src/0.5/en/getting_started/wasm.md
+++ b/docs-src/0.5/en/getting_started/wasm.md
@@ -25,7 +25,7 @@ The Web is the best-supported target platform for Dioxus.
 To develop your Dioxus app for the web, you'll need a tool to build and serve your assets. We recommend using [dioxus-cli](https://github.com/DioxusLabs/dioxus/tree/master/packages/cli) which includes a build system, Wasm optimization, a dev server, and support hot reloading:
 
 ```shell
-cargo install dioxus-cli
+cargo install dioxus-cli@0.5.0-alpha.0
 ```
 
 Make sure the `wasm32-unknown-unknown` target for rust is installed:


### PR DESCRIPTION
In tailwind doc (docs-src/0.5/en/cookbook/tailwind.md),
1. _cargo install --git https://github.com/DioxusLabs/cli_ replaced with _cargo install dioxus-cli_
2. typo fixed: _maganis_ corrected to _manganis_
