### PR TITLE
Document assets support in optimization documentation and fix hooks migration link

### DIFF
--- a/docs-src/0.5/en/cookbook/optimizing.md
+++ b/docs-src/0.5/en/cookbook/optimizing.md
@@ -140,6 +140,6 @@ To see an example of this, check out [Dynamic Rendering](../reference/dynamic_re
 Also check out [Anti-patterns](antipatterns.md) for patterns that you should avoid.
 Obviously, not all of them are just about performance, but some of them are.
 
-## Bundling and minifying the output JS and HTML
+## Optimizing the size of assets
 
-This will be added in [dioxus/#1369](https://github.com/DioxusLabs/dioxus/pull/1369).
+Assets can be a significant part of your app's size. Dioxus includes alpha support for first party [assets](../reference/assets.md). Any assets you include with the `mg!` macro will be optimized for production in release builds.

--- a/docs-src/0.5/en/migration/hooks.md
+++ b/docs-src/0.5/en/migration/hooks.md
@@ -33,7 +33,7 @@ Dioxus 0.5:
 
 ### Dependencies
 
-Some hooks including `use_effect` and `use_resource` now take a single closure with automatic subscriptions instead of a tuple of dependencies. You can read more about the `use_resource` hook in the [Hook Migration](hook.md) guide.
+Some hooks including `use_effect` and `use_resource` now take a single closure with automatic subscriptions instead of a tuple of dependencies. You can read more about the `use_resource` hook in the [Hook Migration](hooks.md) guide.
 
 Dioxus 0.4:
 

--- a/docs-src/0.5/en/migration/index.md
+++ b/docs-src/0.5/en/migration/index.md
@@ -91,7 +91,7 @@ Dioxus 0.5:
 {{#include src/doc_examples/migration.rs:futures}}
 ```
 
-Read more about the `use_resource` hook in the [Hook Migration](hook.md) guide.
+Read more about the `use_resource` hook in the [Hook Migration](hooks.md) guide.
 
 ### State Hooks
 

--- a/docs-src/0.5/en/reference/assets.md
+++ b/docs-src/0.5/en/reference/assets.md
@@ -1,5 +1,7 @@
 # Assets
 
+> ⚠️ Support: Manganis is currently in alpha. API changes are planned and bugs are more likely
+
 Assets are files that are included in the final build of the application. They can be images, fonts, stylesheets, or any other file that is not a source file. Dioxus includes first class support for assets, and provides a simple way to include them in your application and automatically optimize them for production.
 
 Assets in dioxus are also compatible with libraries! If you are building a library, you can include assets in your library and they will be automatically included in the final build of any application that uses your library.


### PR DESCRIPTION
This PR fixes two issues:
1) Fixes the link to the hooks migration page (Fixes #226)
2) Fixes the link to a merged PR for optimizing assets (reported on discord)