### PR TITLE
fix tailwind manganis reference

### DIFF
--- a/src/doc_examples/tailwind.rs
+++ b/src/doc_examples/tailwind.rs
@@ -1,2 +1,2 @@
 // Urls are relative to your Cargo.toml file
-const _TAILWIND_URL: &str = manganis::mg!(file("tailwind.css"));
+const _TAILWIND_URL: &str = manganis::mg!(file("public/tailwind.css"));


### PR DESCRIPTION
[Line 81](https://github.com/DioxusLabs/docsite/blob/24868338b408f07e992b842fe69c7e654bf07df3/docs-src/0.5/en/cookbook/tailwind.md?plain=1#L81) of the Tailwind Cookbook outputs `tailwind.css` into the `public` directory. As the [tailwind.rs](https://github.com/DioxusLabs/docsite/blob/24868338b408f07e992b842fe69c7e654bf07df3/src/doc_examples/tailwind.rs#L1) example states that "Urls are relative to your Cargo.toml file", [line 2](https://github.com/DioxusLabs/docsite/blob/24868338b408f07e992b842fe69c7e654bf07df3/src/doc_examples/tailwind.rs#L2) of the tailwind.rs example should point to `public/tailwind.css`.