### PR TITLE
Remove the web platform specific instructions from the guide

### DIFF
--- a/docs-src/0.5/en/guide/index.md
+++ b/docs-src/0.5/en/guide/index.md
@@ -11,17 +11,3 @@ DemoFrame {
 ```
 
 This guide serves a very brief overview of Dioxus. Throughout the guide, there will be links to the [reference](../reference/index.md) with more details about specific concepts.
-
-## Setup
-Before you start the guide, make sure you have the dioxus CLI and a project set up for your platform as described in the [getting started](../getting_started/index.md) guide.
-
-First, lets setup our dependencies. In addition to the dependencies you added in the [getting started](../getting_started/index.md) guide for your platform, we need to set up a few more dependencies to work with the hacker news API:
-
-```sh
-cargo add chrono --features serde
-cargo add futures
-cargo add reqwest --features json
-cargo add serde --features derive
-cargo add serde_json
-cargo add async_recursion
-```

--- a/docs-src/0.5/en/guide/your_first_component.md
+++ b/docs-src/0.5/en/guide/your_first_component.md
@@ -2,17 +2,37 @@
 
 This chapter will teach you how to create a [Component](../reference/components.md) that displays a link to a post on hackernews.
 
-First, let's define how to display a post. Dioxus is a *declarative* framework. This means that instead of telling Dioxus what to do (e.g. to "create an element" or "set the color to red") we simply *declare* how we want the UI to look.
+## Setup
+
+> Before you start the guide, make sure you have the dioxus CLI and any required dependencies for your platform as described in the [getting started](../getting_started/index.md) guide.
+
+First, let's create a new project for our hacker news app. We can use the CLI to create a new project. You can select a platform of your choice or view the getting started guide for more information on each option. If you aren't sure what platform to try out, we recommend getting started with web or desktop:
+
+```sh
+dx new
+```
+
+The template contains some boilerplate to help you get started. For this guide, we will be rebuilding some of the code from scratch for learning purposes. You can clear the `src/main.rs` file. We will be adding new code in the next sections.
+
+Next, let's setup our dependencies. We need to set up a few dependencies to work with the hacker news API: 
+
+```sh
+cargo add chrono --features serde
+cargo add futures
+cargo add reqwest --features json
+cargo add serde --features derive
+cargo add serde_json
+cargo add async_recursion
+```
+
+## Describing the UI
+
+Now, we can define how to display a post. Dioxus is a *declarative* framework. This means that instead of telling Dioxus what to do (e.g. to "create an element" or "set the color to red") we simply *declare* how we want the UI to look. 
 
 To declare what you want your UI to look like, you will need to use the `rsx` macro. Let's create a ``main`` function and an ``App`` component to show information about our story:
 
 ```rust
 {{#include src/doc_examples/hackernews_post.rs:story_v1}}
-```
-
-Before running your application, you will need to add Dioxus as a dependency:
-```bash
-cargo add dioxus@0.5.0 --features web
 ```
 
 Now if you run your application you should see something like this:


### PR DESCRIPTION
This PR removes a section from the hacker news guide that is specific to the web section and moves the getting started instructions to the first page under the guide