### PR TITLE
Update Log Integration Page for Dioxus Logger 0.5

### DIFF
--- a/docs-src/0.5/en/cookbook/integrations/logging.md
+++ b/docs-src/0.5/en/cookbook/integrations/logging.md
@@ -1,79 +1,44 @@
 # Logging
-Dioxus has a wide range of supported platforms, each with their own logging requirements. We'll discuss the different options available to you.
+Dioxus has a wide range of supported platforms, each with their own logging requirements. We'll discuss the different options available for your projects.
 
-#### The Log Crate
-The [Log](https://crates.io/crates/log) crate is the most universally recognized logging facade in Rust. It is also the easiest to work with in Dioxus; therefore we will be focusing on loggers that work with this crate.
+#### The Tracing Crate
+The [Tracing](https://crates.io/crates/tracing) crate is the logging interface that the Dioxus library uses. It is not required to use the Tracing crate, but you will not recieve logs from the Dioxus library.
 
-The log crate provides a variety of simple `println`-like macros with varying levels of severity. 
+The Tracing crate provides a variety of simple `println`-like macros with varying levels of severity. 
 The available macros are as follows with the highest severity on the bottom:
 ```rs
 fn main() {
-    log::trace!("trace");
-    log::debug!("debug");
-    log::info!("info");
-    log::warn!("warn");
-    log::error!("error");
+    tracing::trace!("trace");
+    tracing::debug!("debug");
+    tracing::info!("info");
+    tracing::warn!("warn");
+    tracing::error!("error");
 }
 ```
-All the loggers provided on this page are, besides configuration and initialization, interfaced using these macros. Often you will also utilize the log crate's `LevelFilter` enum. This enum usually represents the lowest log severity you want your application to emit and can be loaded from a configuration file, environment variable, or other.
+All the loggers provided on this page are, besides configuration and initialization, interfaced using these macros. Often you will also utilize the Tracing crate's `Level` enum. This enum usually represents the maximum log severity you want your application to emit and can be loaded from a variety of sources such as configuration file, environment variable, and more.
 
-For more information, visit log crate's [docs](https://docs.rs/log/latest/log/).
+For more information, visit the Tracing crate's [docs](https://docs.rs/tracing/latest/tracing/).
 
 ## Dioxus Logger
-[Dioxus Logger](https://crates.io/crates/dioxus-logger) is a planned-to-be feature-rich logger that supports all of Dioxus' platforms. Currently only Desktop, Web, and any server-based targets work with Dioxus Logger.
+[Dioxus Logger](https://crates.io/crates/dioxus-logger) is a logging utility that will start the appropriate logger for the platform. Currently every platform except mobile is supported.
 
-The easiest way to use Dioxus Logger is by calling the `init()` function:
+To use Dioxus Logger, call the `init()` function:
 ```rs
-use log::LevelFilter;
+use tracing::Level;
 
 fn main() {
     // Init logger
-    dioxus_logger::init(LevelFilter::Info).expect("failed to init logger");
-    // Dioxus code
+    dioxus_logger::init(Level::INFO).expect("failed to init logger");
+    // Dioxus launch code
 }
 ```
-The `dioxus_logger::init()` function initializes Dioxus Logger with the log crate using the default configuration and provided `LevelFilter`.
-
-#### Custom Format
-Dioxus Logger allows you more control with the ability to set a custom format using the `new` function on the `DioxusLogger` struct:
-```rs
-use log::LevelFilter;
-
-fn main() {
-    // Init logger
-    dioxus_logger::DioxusLogger::new(LevelFilter::Info)
-        .use_format("[{LEVEL}] {PATH} - {ARGS}")
-        .build()
-        .expect("failed to init logger");
-
-    // Dioxus code
-}
-```
-In this example, we are building a new `DioxusLogger` struct, providing the `LevelFilter`, calling the `use_format()` function, and initializing the logger with the `build()` function (acts as `init()` in the previous example).
-
-The key function call in this example is `use_format()`. This function takes a `&str` that specifies how you want your logs to be formatted. To specify a variable in the format, you wrap it's name in `{}`.
-
-The available variables are:
-- LEVEL     - The `LevelFilter` of the emitted log.
-- PATH      - The file path of where the log was emitted, or the crate name.
-- ARGS      - The arguments passed through the log macro.
-- TIMESTAMP - A timestamp of when the log was emitted. (Requires `timestamps` feature)
-
-#### Timestamps
-
-Another feature of Dioxus Logger is the ability to include timestamps with your logs. By default, this feature is disabled and has to be enabled by adding `timestamps` to your features section of the `dioxus-logger` dependency:
-```toml
-dioxus-logger = { version = "*", features = ["timestamps"] }
-```
-
-By enabling this feature, you gain access to the `TIMESTAMP` format variable.
-
+The `dioxus_logger::init()` function initializes Dioxus Logger with the appropriate tracing logger using the default configuration and provided `Level`.
 
 #### Platform Intricacies
-On web, Dioxus Logger will use [web-sys](https://crates.io/crates/web-sys) to interact with `console.log()` to output your logs to the browser's console. On Desktop and server-based targets, Dioxus Logger will output using `println()`.
+On web, Dioxus Logger will use [tracing-wasm](https://crates.io/crates/tracing-wasm). On Desktop and server-based targets, Dioxus Logger will use [tracing-subscriber](https://crates.io/crates/tracing-subscriber)'s `FmtSubscriber`.
 
 #### Final Notes
-Dioxus Logger is the preferred logger to use with Dioxus if it suites your needs. There are many more features to come and Dioxus Logger is planned to become an integral part of Dioxus. If there are any feature suggestions or issues with Dioxus Logger, feel free to reach out on the [Dioxus Discord Server](https://discord.gg/XgGxMSkvUM)!
+Dioxus Logger is the preferred logger to use with Dioxus if it suites your needs. There are more features to come and Dioxus Logger is planned to become an integral part of Dioxus. If there are any feature suggestions or issues with Dioxus Logger, feel free to reach out on the [Dioxus Discord Server](https://discord.gg/XgGxMSkvUM)!
 
 For more information, visit Dioxus Logger's [docs](https://docs.rs/dioxus-logger/latest/dioxus_logger/).
 
@@ -82,45 +47,41 @@ For Dioxus' desktop and server targets, you can generally use the logger of your
 
 
 Some popular options are:
-- [env_logger](https://crates.io/crates/env_logger)
-- [simple_logger](https://crates.io/crates/simple_logger)
-- [pretty_env_logger](https://crates.io/crates/pretty_env_logger) 
+- [tracing-subscriber](https://crates.io/crates/tracing-subscriber)'s `FmtSubscriber` for console output.
+- [tracing-appender](https://crates.io/crates/tracing-appender) for logging to files.
+- [tracing-bunyan-formatter](https://crates.io/crates/tracing-bunyan-formatter) for the Bunyan format.
 
-To keep this guide short, we will not be covering the usage of these loggers.
+To keep this guide short, we will not be covering the usage of these crates.
 
-
-For a full list of popular log-based logging crates, visit [this](https://docs.rs/log/latest/log/#available-logging-implementations) list in the log crate's docs.
+For a full list of popular tracing-based logging crates, visit [this](https://docs.rs/tracing/latest/tracing/#related-crates) list in the Tracing crate's docs.
 
 ## Web
-[WASM Logger](https://crates.io/crates/wasm-logger) is a logging interface that can be used with Dioxus' web platform.
+[tracing-wasm](https://crates.io/crates/tracing-wasm) is a logging interface that can be used with Dioxus' web platform.
 
-The easiest way to use WASM Logger is with the `init` function:
+The easiest way to use WASM Logger is with the `set_as_global_default` function:
 ```rs
 fn main() {
     // Init logger
-    wasm_logger::init(wasm_logger::Config::default());
-
+    tracing_wasm::set_as_global_default();
     // Dioxus code
 }
 ```
-This starts WASM Logger with a `LevelFilter` of `Debug`. 
+This starts tracing with a `Level` of `Trace`. 
 
-To specify a custom `LevelFilter`, build the `Config` struct:
+Using a custom `level` is a little trickier. We need to use the `WasmLayerConfigBuilder` and start the logger with `set_as_global_default_with_config()`:
 ```rs
-use log::LevelFilter;
+use tracing::Level;
 
 fn main() {
     // Init logger
-    let log_config = wasm_logger::Config::new(LevelFilter::Info);
-    wasm_logger::init(log_config);
-
+    let tracing_config = tracing_wasm::WASMLayerConfigBuilder::new().set_max_level(Level::INFO).build();
+    tracing_wasm::set_as_global_default_with_config(tracing_config);
     // Dioxus code
 }
 ```
-#### Platform Intricacies
-WASM Logger also uses the [web-sys](https://crates.io/crates/web-sys) crate to output to the console.
 
-For more information, visit wasm-logger's [docs](https://docs.rs/wasm-logger/latest/wasm_logger/).
+# Mobile
+Unfortunately there are no tracing crates that work with mobile targets. As an alternative you can use the [log](https://crates.io/crates/log) crate.
 
 ## Android
 [Android Logger](https://crates.io/crates/android_logger) is a logging interface that can be used when targeting Android. Android Logger runs whenever an event `native_activity_create` is called by the Android system:


### PR DESCRIPTION
[Dioxus Logger](https://github.com/DogeDark/dioxus-logger) has been updated to use the tracing crate. This PR updates the logging integration page to provide solutions using the tracing crate instead of log.