### PR TITLE
Fix: tauri prereqs link + mention localhost:8080 on Getting Started Page

### DIFF
--- a/docs-src/0.5/en/getting_started/index.md
+++ b/docs-src/0.5/en/getting_started/index.md
@@ -85,6 +85,8 @@ cd my_project
 dx serve
 ```
 
+For Web targets the application will be served at [http://localhost:8080](http://localhost:8080)
+
 ## Conclusion
 
 That's it! You now have a working Dioxus project. You can continue learning about dioxus by [making a hackernews clone in the guide](../guide/index.md), or learning about specific topics/platforms in the [reference](../reference/index.md). If you have any questions, feel free to ask in the [discord](https://discord.gg/XgGxMSkvUM) or [open a discussion](https://github.com/DioxusLabs/dioxus/discussions).

--- a/src/components/desktop_dependencies.rs
+++ b/src/components/desktop_dependencies.rs
@@ -140,7 +140,7 @@ fn LinuxDependencies() -> Element {
                 "If you run into issues, make sure you have all the basics installed, as outlined in the "
                 Link {
                     "Tauri docs"
-                    to: "https://beta.tauri.app/guides/prerequisites/"
+                    to: "https://beta.tauri.app/start/prerequisites/"
                 }
                 "."
             }


### PR DESCRIPTION

The Tauri link from [Getting Started](https://dioxuslabs.com/learn/0.5/getting_started#platform-specific-dependencies)  now gives a 404.
Looks like it's changed from https://beta.tauri.app/guides/prerequisites/ to https://beta.tauri.app/start/prerequisites/

I also added that `dx serve`  will serve Web targets at http://localhost:8080 as it wasn't clear from the getting started page and isn't mentioned in the generated app src or `dx serve` log. Though the `dx serve` log may be a better place for it.

```
Dioxus @ v0.5.4 [16:33:50]

    > Hot Reload Mode: RSX
    > Watching: [ src, assets, Cargo.toml, Dioxus.toml ]
    > Custom index.html: None
    > Serve index.html on 404: True

    > Build Features: [ server ]
    > Build Profile: Debug
    > Build took: 16580 millis

2024-04-26T06:36:58.352975Z  INFO dioxus_fullstack::render: Rebuilding vdom
2024-04-26T06:36:58.353099Z  INFO dioxus_fullstack::render: Suspense resolved
spinning up hot reloading
connecting to "/home/.../dioxus-0-5-fullstack-test/target/dioxusin"
Connected to hot reloading 🚀
hot reloading ready
🔥 Hot Reload WebSocket connected
🔮 Finding updates since last compile...
finished
2024-04-26T06:42:18.739002Z  INFO dioxus_0_5_fullstack_test: Server received: Hello from the server!

```