### PR TITLE
Fix linux dependencies

### DIFF
--- a/src/components/desktop_dependencies.rs
+++ b/src/components/desktop_dependencies.rs
@@ -134,7 +134,7 @@ fn LinuxDependencies() -> Element {
     rsx! {
         div {
             p {
-                "WebView Linux apps require WebkitGtk. When distributing, this can be part of your dependency tree in your `.rpm` or `.deb`. However, likely, your users will already have WebkitGtk."
+                "WebView Linux apps require WebkitGtk and xdotool. When distributing, these should be part of your dependency tree in your `.rpm` or `.deb`."
             }
             p {
                 "If you run into issues, make sure you have all the basics installed, as outlined in the "


### PR DESCRIPTION
I just started a dioxus desktop linux app, and on first compile ld complained about not being able to find libxdo, and upon installing xdotool it started to work. In further runs after uninstalling xdotool, it started to error again at runtime. I use wayland near-exclusively, so I had no reason to ever install xdotool which provides libxdo. As far as I can tell, this requirement is never mentioned in neither the dioxus nor tauri docs. I did however run a tauri app earlier, so as far as I can tell this dependency is just a dioxus thing.

As this seems to be a hard runtime dependency, this should really be mentioned.

![Screenshot_20240428_144830](https://github.com/DioxusLabs/docsite/assets/109437372/b6403637-fc75-4720-ad50-5a61d45e4dc6)