### PR TITLE
fix cargo install commands, s/0.5/0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ changes you can install the [`dx`][dx] tool locally, assuming you already have a
 working `Rust` setup:
 
 ```sh
-cargo install dioxus-cli@0.5
+cargo install dioxus-cli@0.5.0
 ```
 
 With [`dx`][dx] installed, you can use it to build and serve the documentation

--- a/docs-src/0.5/en/cookbook/publishing.md
+++ b/docs-src/0.5/en/cookbook/publishing.md
@@ -64,7 +64,7 @@ The first thing we'll do is install the [dioxus-cli](https://github.com/DioxusLa
 
 To install, simply run
 
-`cargo install dioxus-cli@0.5`
+`cargo install dioxus-cli@0.5.0`
 
 ## Building
 

--- a/docs-src/0.5/en/cookbook/tailwind.md
+++ b/docs-src/0.5/en/cookbook/tailwind.md
@@ -10,7 +10,7 @@ One popular option for styling your Dioxus application is [Tailwind](https://tai
 1. Install the Dioxus CLI:
 
 ```bash
-cargo install dioxus-cli@0.5
+cargo install dioxus-cli@0.5.0
 ```
 
 2. Install npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

--- a/docs-src/0.5/en/getting_started/index.md
+++ b/docs-src/0.5/en/getting_started/index.md
@@ -34,7 +34,7 @@ DesktopDependencies {}
 Next, lets install the Dioxus CLI:
 
 ```
-cargo install dioxus-cli@0.5
+cargo install dioxus-cli@0.5.0
 ```
 
 If you get an OpenSSL error on installation, ensure the dependencies listed [here](https://docs.rs/openssl/latest/openssl/#automatic) are installed.


### PR DESCRIPTION
I found a few places in the docs that suggest running this command to install the dioxus cli:

```
cargo install dioxus-cli@0.5
```

Several other places in the docs suggest this command:

```
cargo install dioxus-cli@0.5.0
```

However, cargo doesn't like that version specifier.

```
$ cargo install dioxus-cli@0.5
error: invalid value 'dioxus-cli@0.5' for '[CRATE[@<VER>]]...': unexpected end of input while parsing minor version number

  tip: if you want to specify SemVer range, add an explicit qualifier, like '^0.5'

For more information, try '--help'.
```

This PR changes the `0.5` install commands to `0.5.0` instead.  Though as the cargo error says, `^0.5` might be even better, so I'd be happy to change this PR to that instead.