### PR TITLE
Fix to_owned example in use_coroutine reference

### DIFF
--- a/src/doc_examples/use_coroutine_reference.rs
+++ b/src/doc_examples/use_coroutine_reference.rs
@@ -47,6 +47,7 @@ fn to_owned() {
     let sync_status = use_signal(|| Status::Launching);
     let load_status = use_signal(|| Status::Launching);
     let sync_task = use_coroutine(|rx: UnboundedReceiver<SyncAction>| {
+        to_owned![sync_status, load_status];
         async move {
             // ...
         }


### PR DESCRIPTION
missing the actual `to_owned!` call