### PR TITLE
Remove on prefix restriction from EventHandler docs

### DIFF
--- a/docs-src/0.5/en/reference/event_handlers.md
+++ b/docs-src/0.5/en/reference/event_handlers.md
@@ -64,7 +64,7 @@ Any event handlers will still be called.
 
 ## Handler Props
 
-Sometimes, you might want to make a component that accepts an event handler. A simple example would be a `FancyButton` component, which accepts an `on_click` handler:
+Sometimes, you might want to make a component that accepts an event handler. A simple example would be a `FancyButton` component, which accepts an `onclick` handler:
 
 ```rust, no_run
 {{#include src/doc_examples/event_handler_prop.rs:component_with_handler}}
@@ -76,7 +76,7 @@ Then, you can use it like any other handler:
 {{#include src/doc_examples/event_handler_prop.rs:usage}}
 ```
 
-> Note: just like any other attribute, you can name the handlers anything you want! Though they must start with `on`, for the prop to be automatically turned into an `EventHandler` at the call site.
+> Note: just like any other attribute, you can name the handlers anything you want! Any closure you pass in will automatically be turned into an `EventHandler`.
 
 ## Custom Data
 

--- a/src/doc_examples/conditional_rendering.rs
+++ b/src/doc_examples/conditional_rendering.rs
@@ -8,22 +8,22 @@ pub fn App() -> Element {
     rsx! {
         LogIn {
             is_logged_in: is_logged_in(),
-            on_log_in: move |_| is_logged_in.set(true),
-            on_log_out: move |_| is_logged_in.set(false)
+            log_in: move |_| is_logged_in.set(true),
+            log_out: move |_| is_logged_in.set(false)
         }
     }
 }
 
 #[component]
-fn LogIn(is_logged_in: bool, on_log_in: EventHandler, on_log_out: EventHandler) -> Element {
+fn LogIn(is_logged_in: bool, log_in: EventHandler, log_out: EventHandler) -> Element {
     // ANCHOR: if_else
     if is_logged_in {
         rsx! {
             "Welcome!"
-            button { onclick: move |_| on_log_out.call(()), "Log Out" }
+            button { onclick: move |_| log_out.call(()), "Log Out" }
         }
     } else {
-        rsx! { button { onclick: move |_| on_log_in.call(()), "Log In" } }
+        rsx! { button { onclick: move |_| log_in.call(()), "Log In" } }
     }
     // ANCHOR_END: if_else
 }
@@ -34,14 +34,14 @@ pub fn LogInImprovedApp() -> Element {
     rsx! {
         LogInImproved {
             is_logged_in: is_logged_in(),
-            on_log_in: move |_| is_logged_in.set(true),
-            on_log_out: move |_| is_logged_in.set(false)
+            log_in: move |_| is_logged_in.set(true),
+            log_out: move |_| is_logged_in.set(false)
         }
     }
 }
 
 #[component]
-fn LogInImproved(is_logged_in: bool, on_log_in: EventHandler, on_log_out: EventHandler) -> Element {
+fn LogInImproved(is_logged_in: bool, log_in: EventHandler, log_out: EventHandler) -> Element {
     // ANCHOR: if_else_improved
     rsx! {
         // We only render the welcome message if we are logged in
@@ -52,7 +52,7 @@ fn LogInImproved(is_logged_in: bool, on_log_in: EventHandler, on_log_out: EventH
         }
         button {
             // depending on the value of `is_logged_in`, we will call a different event handler
-            onclick: move |_| if is_logged_in { on_log_in.call(()) } else { on_log_out.call(()) },
+            onclick: move |_| if is_logged_in { log_in.call(()) } else { log_out.call(()) },
             if is_logged_in {
                 // if we are logged in, the button should say "Log Out"
                 "Log Out"

--- a/src/doc_examples/event_handler_prop.rs
+++ b/src/doc_examples/event_handler_prop.rs
@@ -8,21 +8,21 @@ fn main() {
 
 fn App() -> Element {
     // ANCHOR: usage
-    rsx! { FancyButton { on_click: move |event| println!("Clicked! {event:?}") } }
+    rsx! { FancyButton { onclick: move |event| println!("Clicked! {event:?}") } }
     // ANCHOR_END: usage
 }
 
 // ANCHOR: component_with_handler
 #[derive(PartialEq, Clone, Props)]
 pub struct FancyButtonProps {
-    on_click: EventHandler<MouseEvent>,
+    onclick: EventHandler<MouseEvent>,
 }
 
 pub fn FancyButton(props: FancyButtonProps) -> Element {
     rsx! {
         button {
             class: "fancy-button",
-            onclick: move |evt| props.on_click.call(evt),
+            onclick: move |evt| props.onclick.call(evt),
             "click me pls."
         }
     }
@@ -34,14 +34,14 @@ struct ComplexData(i32);
 
 #[derive(PartialEq, Clone, Props)]
 pub struct CustomFancyButtonProps {
-    on_click: EventHandler<ComplexData>,
+    onclick: EventHandler<ComplexData>,
 }
 
 pub fn CustomFancyButton(props: CustomFancyButtonProps) -> Element {
     rsx! {
         button {
             class: "fancy-button",
-            onclick: move |_| props.on_click.call(ComplexData(0)),
+            onclick: move |_| props.onclick.call(ComplexData(0)),
             "click me pls."
         }
     }

--- a/src/doc_examples/meme_editor.rs
+++ b/src/doc_examples/meme_editor.rs
@@ -23,7 +23,7 @@ fn MemeEditor() -> Element {
         div { style: "{container_style}",
             h1 { "Meme Editor" }
             Meme { caption: caption }
-            CaptionEditor { caption: caption, on_input: move |event: FormEvent| caption.set(event.value()) }
+            CaptionEditor { caption: caption, oninput: move |event: FormEvent| caption.set(event.value()) }
         }
     }
 }
@@ -63,7 +63,7 @@ fn Meme(caption: String) -> Element {
 
 // ANCHOR: caption_editor
 #[component]
-fn CaptionEditor(caption: String, on_input: EventHandler<FormEvent>) -> Element {
+fn CaptionEditor(caption: String, oninput: EventHandler<FormEvent>) -> Element {
     let input_style = r"
         border: none;
         background: cornflowerblue;
@@ -77,7 +77,7 @@ fn CaptionEditor(caption: String, on_input: EventHandler<FormEvent>) -> Element 
         input {
             style: "{input_style}",
             value: "{caption}",
-            oninput: move |event| on_input.call(event)
+            oninput: move |event| oninput.call(event)
         }
     }
 }

--- a/src/doc_examples/meme_editor_dark_mode.rs
+++ b/src/doc_examples/meme_editor_dark_mode.rs
@@ -84,7 +84,7 @@ fn MemeEditor() -> Element {
         div { style: "{container_style}",
             h1 { style: "{heading_style}", "Meme Editor" }
             Meme { caption: caption }
-            CaptionEditor { caption: caption, on_input: move |event: FormEvent| caption.set(event.value()) }
+            CaptionEditor { caption: caption, oninput: move |event: FormEvent| caption.set(event.value()) }
         }
     }
 }
@@ -124,7 +124,7 @@ fn Meme(caption: String) -> Element {
 
 // ANCHOR: caption_editor
 #[component]
-fn CaptionEditor(caption: String, on_input: EventHandler<FormEvent>) -> Element {
+fn CaptionEditor(caption: String, oninput: EventHandler<FormEvent>) -> Element {
     let is_dark_mode = use_is_dark_mode();
 
     let colors = if is_dark_mode {
@@ -150,7 +150,7 @@ fn CaptionEditor(caption: String, on_input: EventHandler<FormEvent>) -> Element 
         input {
             style: "{input_style}{colors}",
             value: "{caption}",
-            oninput: move |event| on_input.call(event)
+            oninput: move |event| oninput.call(event)
         }
     }
 }


### PR DESCRIPTION
EventHandler in components no longer looks at the `on` prefix for the attribute name to figure out if something is an event handler. This PR updates the docs to reflect that change