### PR TITLE
Add Section On Async `EventHandler`s

### DIFF
--- a/docs-src/0.5/en/reference/event_handlers.md
+++ b/docs-src/0.5/en/reference/event_handlers.md
@@ -79,13 +79,9 @@ Then, you can use it like any other handler:
 > Note: just like any other attribute, you can name the handlers anything you want! Any closure you pass in will automatically be turned into an `EventHandler`.
 
 #### Async Event Handlers
-Passing `EventHandler`s as props does not support passing a closure that returns an async block:
+Passing `EventHandler`s as props does not support passing a closure that returns an async block. Instead, you must manually call ``spawn`` to do async operations:
 ```rust, no_run
-{{#include src/doc_examples/event_handler_prop.rs:async_bad}}
-```
-Instead, you must manually call ``spawn`` to do async operations:
-```rust, no_run
-{{#include src/doc_examples/event_handler_prop.rs:async_good}}
+{{#include src/doc_examples/event_handler_prop.rs:async}}
 ```
 This is only the case for custom event handlers as props.
 

--- a/docs-src/0.5/en/reference/event_handlers.md
+++ b/docs-src/0.5/en/reference/event_handlers.md
@@ -78,6 +78,17 @@ Then, you can use it like any other handler:
 
 > Note: just like any other attribute, you can name the handlers anything you want! Any closure you pass in will automatically be turned into an `EventHandler`.
 
+#### Async Event Handlers
+Passing `EventHandler`s as props does not support passing a closure that returns an async block:
+```rust, no_run
+{{#include src/doc_examples/event_handler_prop.rs:async_bad}}
+```
+Instead, you must manually call ``spawn`` to do async operations:
+```rust, no_run
+{{#include src/doc_examples/event_handler_prop.rs:async_good}}
+```
+This is only the case for custom event handlers as props.
+
 ## Custom Data
 
 Event Handlers are generic over any type, so you can pass in any data you want to them, e.g:

--- a/src/doc_examples/event_handler_prop.rs
+++ b/src/doc_examples/event_handler_prop.rs
@@ -8,7 +8,12 @@ fn main() {
 
 fn App() -> Element {
     // ANCHOR: usage
-    rsx! { FancyButton { onclick: move |event| println!("Clicked! {event:?}") } }
+    rsx! {
+        FancyButton {
+            onclick: move |event| println!("Clicked! {event:?}"),
+            "this is a button"
+        }
+    }
     // ANCHOR_END: usage
 }
 
@@ -47,3 +52,33 @@ pub fn CustomFancyButton(props: CustomFancyButtonProps) -> Element {
     }
 }
 // ANCHOR_END: custom_data
+
+pub fn MyComponent() -> Element {
+    // ANCHOR: async_bad
+    rsx! {
+        FancyButton {
+            // This does not work!
+            onclick: move |event| async move {
+                 println!("Clicked! {event:?}");
+            },
+            "this is a button"
+        }
+    }
+    // ANCHOR_END: async_bad
+}
+
+pub fn MyComponent() -> Element {
+    // ANCHOR: async_good
+    rsx! {
+        FancyButton {
+            // This works!
+            onclick: move |event| {
+                spawn(async move {
+                    println!("Clicked! {event:?}");
+                });
+            },
+            "this is a button"
+        }
+    }
+    // ANCHOR_END: async_good
+}

--- a/src/doc_examples/event_handler_prop.rs
+++ b/src/doc_examples/event_handler_prop.rs
@@ -9,9 +9,8 @@ fn main() {
 fn App() -> Element {
     // ANCHOR: usage
     rsx! {
-        FancyButton {
-            onclick: move |event| println!("Clicked! {event:?}"),
-            "this is a button"
+        FancyButton { 
+            onclick: move |event| println!("Clicked! {event:?}"), 
         }
     }
     // ANCHOR_END: usage
@@ -54,31 +53,21 @@ pub fn CustomFancyButton(props: CustomFancyButtonProps) -> Element {
 // ANCHOR_END: custom_data
 
 pub fn MyComponent() -> Element {
-    // ANCHOR: async_bad
+    // ANCHOR: async
     rsx! {
         FancyButton {
             // This does not work!
-            onclick: move |event| async move {
-                 println!("Clicked! {event:?}");
-            },
-            "this is a button"
-        }
-    }
-    // ANCHOR_END: async_bad
-}
+            // onclick: move |event| async move {
+            //      println!("Clicked! {event:?}");
+            // },
 
-pub fn MyComponent() -> Element {
-    // ANCHOR: async_good
-    rsx! {
-        FancyButton {
-            // This works!
+            // This does work!
             onclick: move |event| {
                 spawn(async move {
                     println!("Clicked! {event:?}");
                 });
             },
-            "this is a button"
         }
     }
-    // ANCHOR_END: async_good
+    // ANCHOR_END: async
 }


### PR DESCRIPTION
Adds a small section to the page about passing event handlers as props. This section describes how async event handlers require a bit more effort to work.