### PR TITLE
Fix: Use Latest `docs.rs` Link

### DIFF
--- a/src/components/nav.rs
+++ b/src/components/nav.rs
@@ -82,7 +82,7 @@ static LINKS: &[(&str, &str)] = &[
     ("Learn", "/learn/0.5/"),
     ("Blog", "/blog"),
     ("Awesome", "/awesome"),
-    ("docs.rs", "https://docs.rs/dioxus/0.5.0/dioxus/index.html"),
+    ("docs.rs", "https://docs.rs/dioxus/latest/dioxus/"),
 ];
 
 #[component]


### PR DESCRIPTION
Changes the `docs.rs` link in the navbar to use `/dioxus/latest` instead of `/dioxus/0.5.0` so that it always routes to the latest `docs.rs`.