### PR TITLE
fix: add liveview compilation note

### DIFF
--- a/docs-src/0.5/en/getting_started/index.md
+++ b/docs-src/0.5/en/getting_started/index.md
@@ -85,6 +85,8 @@ cd my_project
 dx serve
 ```
 
+For projects using the liveview template, run `dx serve --desktop`.
+
 For Web targets the application will be served at [http://localhost:8080](http://localhost:8080)
 
 ## Conclusion


### PR DESCRIPTION
- Running dx serve using a liveview starter template will fail to compile given the getting started directions

- Ref: https://github.com/DioxusLabs/dioxus/issues/2530

# Details
Unfortunately, not knowing that selecting `liveview` from the starter template cost me about an hour to work with dioxus. Definitely skill issued here, but I don't want this to happen to others. Following the existing docs, but selecting `Liveview`, will not compile. Just for reference, I have included the steps I originally wrote in my issue until I realized there was an [existing open one](https://github.com/DioxusLabs/dioxus/issues/2530). 

This is definitely a like minor change, but hopefully y'all can see how not knowing anything about the platform leads to the conclusion.

## Properties

Host Machine Properties:
CPU: `Apple M3 Max`
OS: `macOS Sonoma 14.5`
Shell: `zsh`
Target: `stable-aarch64-apple-darwin unchanged - rustc 1.79.0 (129f3b996 2024-06-10)`

## Command walkthrough leading to error

### Install `dioxus-cli`
```shell
danielgallups@Daniels-MBP ~ % cargo install dioxus-cli
    Updating crates.io index
  Installing dioxus-cli v0.5.4
    Updating crates.io index
     Locking 681 packages to latest compatible versions
      Adding addr2line v0.22.0 (latest: v0.23.0)
      <...>
    Finished `release` profile [optimized] target(s) in 1m 30s
  Installing /Users/danielgallups/.cargo/bin/dx
   Installed package `dioxus-cli v0.5.4` (executable `dx`)
```

### Create a new project
I am using the `Liveview` template
```shell
danielgallups@Daniels-MBP ~ % dx new
✔ 🤷   Which sub-template should be expanded? · Liveview
🤷   Project Name: testdioxus
✔ 🤷   Should the application use the Dioxus router? · true
```

### Change dir
```shell
danielgallups@Daniels-MBP ~ % cd testdioxus 
danielgallups@Daniels-MBP testdioxus % 
```

### Serve
```shell
danielgallups@Daniels-MBP testdioxus % dx serve
/ ⚙️ Compiling registry+https://github.com/rust-lang/crates.io-index#libc@0.2.155                                                                   error[E0432]: unresolved import `crate::sys::IoSourceState`
  --> /Users/danielgallups/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-0.8.11/src/io_source.rs:12:5
   |
12 | use crate::sys::IoSourceState;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `IoSourceState` in `sys`
  <...>
  <...>
note: `Source` defines an item `reregister`, perhaps you need to implement it
   --> /Users/danielgallups/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-0.8.11/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0599]: no method named `deregister` found for struct `IoSource<std::net::UdpSocket>` in the current scope
   --> /Users/danielgallups/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-0.8.11/src/net/udp.rs:635:20
    |
635 |         self.inner.deregister(registry)
    |                    ^^^^^^^^^^ method not found in `IoSource<UdpSocket>`
    |
   ::: /Users/danielgallups/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-0.8.11/src/io_source.rs:62:1
    |
62  | pub struct IoSource<T> {
    | ---------------------- method `deregister` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `deregister`, perhaps you need to implement it
   --> /Users/danielgallups/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-0.8.11/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^
Some errors have detailed explanations: E0412, E0425, E0432, E0433, E0599.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `mio` (lib) due to 44 previous errors
Error: 🚫 Serving project failed:

Caused by:
    Build failed
```

**Expected behavior**

The project is expected to open a tcp socket on `http://localhost:8080`