### PR TITLE
Update hackernews_complete.rs

### DIFF
--- a/src/doc_examples/hackernews_complete.rs
+++ b/src/doc_examples/hackernews_complete.rs
@@ -51,7 +51,7 @@ async fn resolve_story(
 
 #[component]
 fn StoryListing(story: ReadOnlySignal<StoryItem>) -> Element {
-    let mut preview_state = consume_context::<Signal<PreviewState>>();
+    let preview_state = consume_context::<Signal<PreviewState>>();
     let StoryItem {
         title,
         url,


### PR DESCRIPTION
The hackernews reader works with an immutable preview_state aswell. Why should it be mutable? Rust analyzer also gives a warning when declaring a mutable preview_state.