### PR TITLE
Fix broken link that points to outdated fullstack auth example

### DIFF
--- a/docs-src/0.5/en/reference/fullstack/authentication.md
+++ b/docs-src/0.5/en/reference/fullstack/authentication.md
@@ -4,4 +4,4 @@ You can use [extractors](./extractors) to integrate auth with your Fullstack app
 
 You can create a custom extractors that extracts the auth session from the request. From that auth session, you can check if the user has the required privileges before returning the private data.
 
-A [full auth example](https://github.com/DioxusLabs/dioxus/blob/main/packages/fullstack/examples/auth/src/main.rs) with the complete implementation is available in the fullstack examples.
+A [full auth example](https://github.com/DioxusLabs/dioxus/blob/v0.5/packages/fullstack/examples/axum-auth/src/main.rs) with the complete implementation is available in the fullstack examples.

--- a/docs-src/0.5/en/reference/fullstack/authentication.md
+++ b/docs-src/0.5/en/reference/fullstack/authentication.md
@@ -4,4 +4,4 @@ You can use [extractors](./extractors) to integrate auth with your Fullstack app
 
 You can create a custom extractors that extracts the auth session from the request. From that auth session, you can check if the user has the required privileges before returning the private data.
 
-A [full auth example](https://github.com/dioxuslabs/dioxus/blob/main/packages/fullstack/examples/axum-auth/src/main.rs) with the complete implementation is available in the fullstack examples.
+A [full auth example](https://github.com/DioxusLabs/dioxus/blob/main/packages/fullstack/examples/auth/src/main.rs) with the complete implementation is available in the fullstack examples.


### PR DESCRIPTION
**TLDR**; `axum-auth` should be `auth` in the docs site now that we've updated it in the code and the linked path in the docs is invalid.

**Description:**
Noticed a 404 when navigating to the [fullstack auth example](https://dioxuslabs.com/learn/0.5/reference/fullstack/authentication) provided on the docs page. Looks like that file path no longer exists and was recently updated.

This PR updates the docs page (where what I think is the right spot?) to use the new file path.