### PR TITLE
Make the hook rules more consistent

### DIFF
--- a/docs-src/0.5/en/guide/state.md
+++ b/docs-src/0.5/en/guide/state.md
@@ -68,11 +68,11 @@ DemoFrame {
 
 Hooks are a powerful way to manage state in Dioxus, but there are some rules you need to follow to insure they work as expected. Dioxus uses the order you call hooks to differentiate between hooks. Because the order you call hooks matters, you must follow these rules:
 
-1. Hooks may be only used in components or other hooks (we'll get to that later)
+1. Hooks may be only used in components or other hooks (we'll get to that later).
 2. On every call to the component function
-   1. The same hooks must be called
-   2. In the same order
-3. Hooks name's should start with `use_` so you don't accidentally confuse them with regular functions
+   1. the same hooks must be called (except in the case of early returns, as explained later in the [Error Handling chapter](../../cookbook/error_handling.md))
+   2. in the same order.
+3. Hooks name's should start with `use_` so you don't accidentally confuse them with regular functions (`use_signal()`, `use_signal()`, `use_resource()`, etc...).
 
 These rules mean that there are certain things you can't do with hooks:
 

--- a/docs-src/0.5/en/reference/hooks.md
+++ b/docs-src/0.5/en/reference/hooks.md
@@ -67,11 +67,10 @@ But how can Dioxus differentiate between multiple hooks in the same component? A
 This is only possible because the two hooks are always called in the same order, so Dioxus knows which is which. Because the order you call hooks matters, you must follow certain rules when using hooks:
 
 1. Hooks may be only used in components or other hooks (we'll get to that later).
-2. On every call to a component function.
-3. The same hooks must be called (except in the case of early returns, as explained later in the [Error Handling chapter](../../cookbook/error_handling.md)).
-4. In the same order.
-5. Hook names should start with `use_` so you don't accidentally confuse them with regular
-   functions (`use_signal()`, `use_signal()`, `use_resource()`, etc...).
+2. On every call to the component function
+   1. the same hooks must be called (except in the case of early returns, as explained later in the [Error Handling chapter](../../cookbook/error_handling.md))
+   2. in the same order.
+3. Hook names should start with `use_` so you don't accidentally confuse them with regular functions (`use_signal()`, `use_signal()`, `use_resource()`, etc...).
 
 These rules mean that there are certain things you can't do with hooks:
 


### PR DESCRIPTION
The rules of hooks [in the guide](https://dioxuslabs.com/learn/0.5/guide/state#the-rules-of-hooks) seem better formatted than [in the reference](https://dioxuslabs.com/learn/0.5/reference/hooks#rules-of-hooks).

This PR makes them equal.