### PR TITLE
File explorer example moved from `examples` to `example-projects`.

### DIFF
--- a/docs-src/0.5/en/reference/desktop/index.md
+++ b/docs-src/0.5/en/reference/desktop/index.md
@@ -12,7 +12,7 @@ Dioxus desktop is built off [Tauri](https://tauri.app/). Right now there are lim
 
 ## Examples
 
-- [File Explorer](https://github.com/DioxusLabs/dioxus/blob/main/examples/file_explorer.rs)
+- [File Explorer](https://github.com/DioxusLabs/dioxus/blob/main/example-projects/file-explorer)
 - [Tailwind App](https://github.com/DioxusLabs/dioxus/tree/v0.5/examples/tailwind)
 
 [![Tailwind App screenshot](./public/static/tailwind_desktop_app.png)](https://github.com/DioxusLabs/dioxus/tree/v0.5/examples/tailwind)

--- a/src/components/homepage/featured_examples.rs
+++ b/src/components/homepage/featured_examples.rs
@@ -23,7 +23,7 @@ pub(crate) fn FeaturedExamples() -> Element {
                         title: "File Explorer",
                         subtitle: "Desktop",
                         description: "Interact with native APIs directly from your UI. Works with a simple `cargo run` and is bundle-ready.",
-                        link: "https://github.com/DioxusLabs/dioxus/blob/main/examples/file_explorer.rs",
+                        link: "https://github.com/DioxusLabs/dioxus/blob/main/example-projects/file-explorer",
                         img_avif: "/static/file_explorer.avif",
                         img: "/static/file_explorer.png",
                         img_alt: "File Explorer"


### PR DESCRIPTION
URLs should point to the new location of the File Explorer example.