### PR TITLE
Add attribution for xkcd image in blog

### DIFF
--- a/posts/templates.html
+++ b/posts/templates.html
@@ -6,7 +6,7 @@
 <p><img src="https://i.imgur.com/9rbAXP9.png"></p>
 <p>There’s obviously still some room to grow as WASM-based UI libraries face unique challenges compared to their JavaScript counterparts. Ultimately, we hope that this update demonstrates what’s really possible with the current React paradigm.</p>
 <p>And, of course, we need to mention that benchmarks never give a truly clear insight into how performant a library is, especially as an app scales. It’s definitely reasonable to believe that as an app grows in size, any other library might come out ahead. You shouldn’t make a decision on the framework for your next project just because it’s slightly more or less performant than any other library based on entirely arbitrary benchmarks.</p>
-<p><img src="https://i.imgur.com/Mfu8QOX.png"></p>
+<p><a href="https://xkcd.com/1691/"><img title="XKCD 1691" src="https://imgs.xkcd.com/comics/optimization.png"></a></p>
 <p>Anyways…</p>
 <h2 id="dioxus-shares-react-s-dna">Dioxus shares React’s DNA</h2>
 


### PR DESCRIPTION
XKCD is licensed under Creative Commons 2.5 which requires attribution
when used. Make the image a link back to the original comic and use the
embedding link provided instead of rehosting on imgur.

Not sure which is the real source for this post as there appears to be a copy in
markdown as well with a different link.
