### PR TITLE
Remove left-over mentioning of owned props

### DIFF
--- a/src/doc_examples/component_owned_props.rs
+++ b/src/doc_examples/component_owned_props.rs
@@ -8,7 +8,6 @@ pub fn App() -> Element {
 // ANCHOR_END: App
 
 // ANCHOR: Likes
-// Remember: Owned props must implement `PartialEq`!
 #[derive(PartialEq, Props, Clone)]
 struct LikesProps {
     score: i32,


### PR DESCRIPTION
The current documentation on props starts off a little bit confusing, because it mentioned "owned props":

![image](https://github.com/user-attachments/assets/42025357-fead-4245-b253-b6a1b76bceb0)

But then it never mentions what owned props are, and one naturally expects that there are borrowed props as well.

This confused me quite a bit, and searching for "borrowed props" revealed that this is probably a left-over from the 0.5 migration. So I would suggest to remove it to avoid confusion.
