### PR TITLE
Temporarily Remove Playground Link

### DIFF
--- a/src/components/nav.rs
+++ b/src/components/nav.rs
@@ -141,7 +141,7 @@ pub(crate) fn Nav() -> Element {
 static LINKS: &[(&str, &str)] = &[
     ("Learn", "/learn/0.5/"),
     // ("SDK", "/sdk"),
-    ("Playground", "/play"),
+    // ("Playground", "/play"),
     // ("Components", "/components"),
     ("Awesome", "/awesome"),
     ("Blog", "/blog"),


### PR DESCRIPTION
Playground doesn't work and people expect it to. Hide the link for now until it does work.