### PR TITLE
Fix GitHub URLs in `Project Structure` page for versions 0.4, 0.5, and 0.6

### DIFF
--- a/docs-src/0.4/en/contributing/project_structure.md
+++ b/docs-src/0.4/en/contributing/project_structure.md
@@ -6,7 +6,7 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [Desktop](https://github.com/DioxusLabs/dioxus/tree/master/packages/desktop): A Render that Runs Dioxus applications natively, but renders them with the system webview
 - [Mobile](https://github.com/DioxusLabs/dioxus/tree/master/packages/mobile): A Render that Runs Dioxus applications natively, but renders them with the system webview. This is currently a copy of the desktop render
-- [Web](https://github.com/DioxusLabs/dioxus/tree/master/packages/Web): Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM
+- [Web](https://github.com/DioxusLabs/dioxus/tree/master/packages/web): Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM
 - [Liveview](https://github.com/DioxusLabs/dioxus/tree/master/packages/liveview): A Render that Runs on the server, and renders using a websocket proxy in the browser
 - [Rink](https://github.com/DioxusLabs/dioxus/tree/master/packages/rink): A Renderer that renders a HTML-like tree into a terminal
 - [TUI](https://github.com/DioxusLabs/dioxus/tree/master/packages/dioxus-tui): A Renderer that uses Rink to render a Dioxus application in a terminal
@@ -26,7 +26,7 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [core](https://github.com/DioxusLabs/dioxus/tree/master/packages/core): The core virtual dom implementation every Dioxus application uses
   - You can read more about the architecture of the core [in this blog post](https://dioxuslabs.com/blog/templates-diffing/) and the [custom renderer section of the guide](../custom_renderer/index.md)
-- [RSX](https://github.com/DioxusLabs/dioxus/tree/master/packages/RSX): The core parsing for RSX used for hot reloading, autoformatting, and the macro
+- [RSX](https://github.com/DioxusLabs/dioxus/tree/master/packages/rsx): The core parsing for RSX used for hot reloading, autoformatting, and the macro
 - [core-macro](https://github.com/DioxusLabs/dioxus/tree/master/packages/core-macro): The rsx! macro used to write Dioxus applications. (This is a wrapper over the RSX crate)
 - [HTML macro](https://github.com/DioxusLabs/dioxus-html-macro): A html-like alternative to the RSX macro
 
@@ -46,5 +46,5 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [hot-reload](https://github.com/DioxusLabs/dioxus/tree/master/packages/hot-reload): Macro that uses the RSX crate to hot reload static parts of any rsx! macro. This macro works with any non-web renderer with an [integration](https://crates.io/crates/dioxus-hot-reload)
 - [autofmt](https://github.com/DioxusLabs/dioxus/tree/master/packages/autofmt): Formats RSX code
-- [rsx-rosetta](https://github.com/DioxusLabs/dioxus/tree/master/packages/RSX-rosetta): Handles conversion between HTML and RSX
+- [rsx-rosetta](https://github.com/DioxusLabs/dioxus/tree/master/packages/rsx-rosetta): Handles conversion between HTML and RSX
 - [CLI](https://github.com/DioxusLabs/dioxus/tree/master/packages/cli): A Command Line Interface and VSCode extension to assist with Dioxus usage

--- a/docs-src/0.5/src/contributing/project_structure.md
+++ b/docs-src/0.5/src/contributing/project_structure.md
@@ -6,7 +6,7 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [Desktop](https://github.com/DioxusLabs/dioxus/tree/main/packages/desktop): A Render that Runs Dioxus applications natively, but renders them with the system webview
 - [Mobile](https://github.com/DioxusLabs/dioxus/tree/main/packages/mobile): A Render that Runs Dioxus applications natively, but renders them with the system webview. This is currently a copy of the desktop render
-- [Web](https://github.com/DioxusLabs/dioxus/tree/main/packages/Web): Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM
+- [Web](https://github.com/DioxusLabs/dioxus/tree/main/packages/web): Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM
 - [Liveview](https://github.com/DioxusLabs/dioxus/tree/main/packages/liveview): A Render that Runs on the server, and renders using a websocket proxy in the browser
 - [Plasmo](https://github.com/DioxusLabs/blitz/tree/master/packages/plasmo): A Renderer that renders a HTML-like tree into a terminal
 - [TUI](https://github.com/DioxusLabs/blitz/tree/master/packages/dioxus-tui): A Renderer that uses Plasmo to render a Dioxus application in a terminal
@@ -26,7 +26,7 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [core](https://github.com/DioxusLabs/dioxus/tree/main/packages/core): The core virtual dom implementation every Dioxus application uses
   - You can read more about the architecture of the core [in this blog post](https://dioxuslabs.com/blog/templates-diffing/) and the [custom renderer section of the guide](../custom_renderer/index.md)
-- [RSX](https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX): The core parsing for RSX used for hot reloading, autoformatting, and the macro
+- [RSX](https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx): The core parsing for RSX used for hot reloading, autoformatting, and the macro
 - [core-macro](https://github.com/DioxusLabs/dioxus/tree/main/packages/core-macro): The rsx! macro used to write Dioxus applications. (This is a wrapper over the RSX crate)
 - [HTML macro](https://github.com/DioxusLabs/dioxus-html-macro): A html-like alternative to the RSX macro
 
@@ -46,5 +46,5 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [hot-reload](https://github.com/DioxusLabs/dioxus/tree/main/packages/hot-reload): Macro that uses the RSX crate to hot reload static parts of any rsx! macro. This macro works with any non-web renderer with an [integration](https://crates.io/crates/dioxus-hot-reload)
 - [autofmt](https://github.com/DioxusLabs/dioxus/tree/main/packages/autofmt): Formats RSX code
-- [rsx-rosetta](https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX-rosetta): Handles conversion between HTML and RSX
+- [rsx-rosetta](https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx-rosetta): Handles conversion between HTML and RSX
 - [CLI](https://github.com/DioxusLabs/dioxus/tree/main/packages/cli): A Command Line Interface and VSCode extension to assist with Dioxus usage

--- a/docs-src/0.6/src/contributing/project_structure.md
+++ b/docs-src/0.6/src/contributing/project_structure.md
@@ -6,7 +6,7 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [Desktop](https://github.com/DioxusLabs/dioxus/tree/main/packages/desktop): A Render that Runs Dioxus applications natively, but renders them with the system webview
 - [Mobile](https://github.com/DioxusLabs/dioxus/tree/main/packages/mobile): A Render that Runs Dioxus applications natively, but renders them with the system webview. This is currently a copy of the desktop render
-- [Web](https://github.com/DioxusLabs/dioxus/tree/main/packages/Web): Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM
+- [Web](https://github.com/DioxusLabs/dioxus/tree/main/packages/web): Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM
 - [Liveview](https://github.com/DioxusLabs/dioxus/tree/main/packages/liveview): A Render that Runs on the server, and renders using a websocket proxy in the browser
 - [Plasmo](https://github.com/DioxusLabs/blitz/tree/master/packages/plasmo): A Renderer that renders a HTML-like tree into a terminal
 - [TUI](https://github.com/DioxusLabs/blitz/tree/master/packages/dioxus-tui): A Renderer that uses Plasmo to render a Dioxus application in a terminal
@@ -26,7 +26,7 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [core](https://github.com/DioxusLabs/dioxus/tree/main/packages/core): The core virtual dom implementation every Dioxus application uses
   - You can read more about the architecture of the core [in this blog post](https://dioxuslabs.com/blog/templates-diffing/)
-- [RSX](https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX): The core parsing for RSX used for hot reloading, autoformatting, and the macro
+- [RSX](https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx): The core parsing for RSX used for hot reloading, autoformatting, and the macro
 - [core-macro](https://github.com/DioxusLabs/dioxus/tree/main/packages/core-macro): The rsx! macro used to write Dioxus applications. (This is a wrapper over the RSX crate)
 - [HTML macro](https://github.com/DioxusLabs/dioxus-html-macro): A html-like alternative to the RSX macro
 
@@ -44,5 +44,5 @@ There are many packages in the Dioxus organization. This document will help you 
 
 - [hot-reload](https://github.com/DioxusLabs/dioxus/tree/main/packages/hot-reload): Macro that uses the RSX crate to hot reload static parts of any rsx! macro. This macro works with any non-web renderer with an [integration](https://crates.io/crates/dioxus-hot-reload)
 - [autofmt](https://github.com/DioxusLabs/dioxus/tree/main/packages/autofmt): Formats RSX code
-- [rsx-rosetta](https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX-rosetta): Handles conversion between HTML and RSX
+- [rsx-rosetta](https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx-rosetta): Handles conversion between HTML and RSX
 - [CLI](https://github.com/DioxusLabs/dioxus/tree/main/packages/cli): A Command Line Interface and VSCode extension to assist with Dioxus usage


### PR DESCRIPTION
Fix GitHub URLs in `Project Structure` page for versions 0.4, 0.5, and 0.6

- Updated the GitHub URLs in the `Project Structure` page for versions 0.4, 0.5, and 0.6
- Ensured all links are up-to-date and correct