### PR TITLE
Document new event handler functionality

### DIFF
--- a/docs-src/0.5/src/reference/event_handlers.md
+++ b/docs-src/0.5/src/reference/event_handlers.md
@@ -39,7 +39,7 @@ Some events will trigger first on the element the event originated at upward. Fo
 If you want to prevent this behavior, you can call `stop_propagation()` on the event:
 
 ```rust, no_run
-{{#include src/doc_examples/event_nested.rs:rsx}}
+{{#include src/doc_examples/untested_05/event_nested.rs:rsx}}
 ```
 
 ## Prevent Default
@@ -49,7 +49,7 @@ Some events have a default behavior. For keyboard events, this might be entering
 In some instances, might want to avoid this default behavior. For this, you can add the `prevent_default` attribute with the name of the handler whose default behavior you want to stop. This attribute can be used for multiple handlers using their name separated by spaces:
 
 ```rust, no_run
-{{#include src/doc_examples/event_prevent_default.rs:prevent_default}}
+{{#include src/doc_examples/untested_05/event_prevent_default.rs:prevent_default}}
 ```
 
 ```inject-dioxus
@@ -67,13 +67,13 @@ Any event handlers will still be called.
 Sometimes, you might want to make a component that accepts an event handler. A simple example would be a `FancyButton` component, which accepts an `onclick` handler:
 
 ```rust, no_run
-{{#include src/doc_examples/event_handler_prop.rs:component_with_handler}}
+{{#include src/doc_examples/untested_05/event_handler_prop.rs:component_with_handler}}
 ```
 
 Then, you can use it like any other handler:
 
 ```rust, no_run
-{{#include src/doc_examples/event_handler_prop.rs:usage}}
+{{#include src/doc_examples/untested_05/event_handler_prop.rs:usage}}
 ```
 
 > Note: just like any other attribute, you can name the handlers anything you want! Any closure you pass in will automatically be turned into an `EventHandler`.
@@ -81,7 +81,7 @@ Then, you can use it like any other handler:
 #### Async Event Handlers
 Passing `EventHandler`s as props does not support passing a closure that returns an async block. Instead, you must manually call ``spawn`` to do async operations:
 ```rust, no_run
-{{#include src/doc_examples/event_handler_prop.rs:async}}
+{{#include src/doc_examples/untested_05/event_handler_prop.rs:async}}
 ```
 This is only the case for custom event handlers as props.
 
@@ -90,5 +90,5 @@ This is only the case for custom event handlers as props.
 Event Handlers are generic over any type, so you can pass in any data you want to them, e.g:
 
 ```rust, no_run
-{{#include src/doc_examples/event_handler_prop.rs:custom_data}}
+{{#include src/doc_examples/untested_05/event_handler_prop.rs:custom_data}}
 ```

--- a/docs-src/0.6/src/reference/event_handlers.md
+++ b/docs-src/0.6/src/reference/event_handlers.md
@@ -60,8 +60,6 @@ DemoFrame {
 
 Any event handlers will still be called.
 
-> Normally, in React or JavaScript, you'd call "preventDefault" on the event in the callback. Dioxus does _not_ currently support this behavior. Note: this means you cannot conditionally prevent default behavior based on the data in the event.
-
 ## Handler Props
 
 Sometimes, you might want to make a component that accepts an event handler. A simple example would be a `FancyButton` component, which accepts an `onclick` handler:
@@ -78,17 +76,18 @@ Then, you can use it like any other handler:
 
 > Note: just like any other attribute, you can name the handlers anything you want! Any closure you pass in will automatically be turned into an `EventHandler`.
 
-#### Async Event Handlers
-Passing `EventHandler`s as props does not support passing a closure that returns an async block. Instead, you must manually call ``spawn`` to do async operations:
-```rust, no_run
-{{#include src/doc_examples/event_handler_prop.rs:async}}
-```
-This is only the case for custom event handlers as props.
-
 ## Custom Data
 
 Event Handlers are generic over any type, so you can pass in any data you want to them, e.g:
 
 ```rust, no_run
 {{#include src/doc_examples/event_handler_prop.rs:custom_data}}
+```
+
+## Returning a value from an event handler
+
+If you want to accept a closure like an event handler that returns a value, you can use the `Callback` type. The callback type accepts two generic arguments, `I`, the input type, and `O`, the output type. Just like `EventHandler`, `Callback` is automatically converted in props and can be easily copied into anywhere in your component:
+
+```rust, no_run
+{{#include src/doc_examples/event_handler_prop.rs:callback}}
 ```

--- a/src/components/learn.rs
+++ b/src/components/learn.rs
@@ -343,7 +343,7 @@ fn VersionWarning() -> Element {
                 "You are currently viewing the docs for Dioxus 0.6.0 which is under construction."
             }
         },
-        CurrentDocsVersion::V05(_) => rsx! {  },
+        CurrentDocsVersion::V05(_) => rsx! {},
         CurrentDocsVersion::V04(_) => rsx! {
             div { class: "flex flex-row items-center justify-start w-full bg-yellow-200 opacity-80 text-yellow-800 text-sm font-normal py-2 px-2 rounded-md mb-4 gap-2",
                 crate::icons::IconWarning {}

--- a/src/doc_examples/spawn.rs
+++ b/src/doc_examples/spawn.rs
@@ -46,7 +46,7 @@ pub fn Tokio() -> Element {
         // ANCHOR_END: tokio
     };
 
-    rsx! {  }
+    rsx! {}
 }
 
 pub fn ToOwnedMacro() -> Element {
@@ -65,5 +65,5 @@ pub fn ToOwnedMacro() -> Element {
         // ANCHOR_END: to_owned_macro
     };
 
-    rsx! {  }
+    rsx! {}
 }

--- a/src/doc_examples/untested_05/event_click.rs
+++ b/src/doc_examples/untested_05/event_click.rs
@@ -1,0 +1,10 @@
+#![allow(non_snake_case)]
+use dioxus::prelude::*;
+
+pub fn App() -> Element {
+    // ANCHOR: rsx
+    rsx! {
+        button { onclick: move |event| log::info!("Clicked! Event: {event:?}"), "click me!" }
+    }
+    // ANCHOR_END: rsx
+}

--- a/src/doc_examples/untested_05/event_handler_prop.rs
+++ b/src/doc_examples/untested_05/event_handler_prop.rs
@@ -52,21 +52,22 @@ pub fn CustomFancyButton(props: CustomFancyButtonProps) -> Element {
 }
 // ANCHOR_END: custom_data
 
-// ANCHOR: callback
-#[derive(PartialEq, Clone, Props)]
-pub struct CounterProps {
-    modify: Callback<u32, u32>,
-}
-
-pub fn Counter(props: CounterProps) -> Element {
-    let mut count = use_signal(|| 1);
-
+pub fn MyComponent() -> Element {
+    // ANCHOR: async
     rsx! {
-        button {
-            onclick: move |_| count.set(props.modify.call(count())),
-            "double"
+        FancyButton {
+            // This does not work!
+            // onclick: move |event| async move {
+            //      println!("Clicked! {event:?}");
+            // },
+
+            // This does work!
+            onclick: move |event| {
+                spawn(async move {
+                    println!("Clicked! {event:?}");
+                });
+            },
         }
-        div { "count: {count}" }
     }
+    // ANCHOR_END: async
 }
-// ANCHOR_END: callback

--- a/src/doc_examples/untested_05/event_nested.rs
+++ b/src/doc_examples/untested_05/event_nested.rs
@@ -1,0 +1,22 @@
+#![allow(non_snake_case)]
+use dioxus::prelude::*;
+
+fn main() {
+    launch(App);
+}
+
+fn App() -> Element {
+    // ANCHOR: rsx
+    rsx! {
+        div { onclick: move |_event| {},
+            "outer"
+            button {
+                onclick: move |event| {
+                    event.stop_propagation();
+                },
+                "inner"
+            }
+        }
+    }
+    // ANCHOR_END: rsx
+}

--- a/src/doc_examples/untested_05/event_prevent_default.rs
+++ b/src/doc_examples/untested_05/event_prevent_default.rs
@@ -1,0 +1,14 @@
+#![allow(non_snake_case)]
+use dioxus::prelude::*;
+
+pub fn App() -> Element {
+    // ANCHOR: prevent_default
+    rsx! {
+        a {
+            href: "https://example.com",
+            prevent_default: "onclick",
+            "example.com"
+        }
+    }
+    // ANCHOR_END: prevent_default
+}

--- a/src/docs/router_04.rs
+++ b/src/docs/router_04.rs
@@ -12707,7 +12707,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 ": A Render that Runs Dioxus applications natively, but renders them with the system webview. This is currently a copy of the desktop render"
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/master/packages/Web",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/master/packages/web",
                     "Web"
                 }
                 ": Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM"
@@ -12803,7 +12803,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 }
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/master/packages/RSX",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/master/packages/rsx",
                     "RSX"
                 }
                 ": The core parsing for RSX used for hot reloading, autoformatting, and the macro"
@@ -12883,7 +12883,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 ": Formats RSX code"
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/master/packages/RSX-rosetta",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/master/packages/rsx-rosetta",
                     "rsx-rosetta"
                 }
                 ": Handles conversion between HTML and RSX"

--- a/src/docs/router_05.rs
+++ b/src/docs/router_05.rs
@@ -6254,7 +6254,7 @@ pub fn ReferenceEventHandlers() -> dioxus::prelude::Element {
             " attribute with the name of the handler whose default behavior you want to stop. This attribute can be used for multiple handlers using their name separated by spaces:"
         }
         CodeBlock {
-            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f8f8f2;\">rsx! {{\n</span><span style=\"color:#f8f8f2;\">    a {{\n</span><span style=\"color:#f8f8f2;\">        href: </span><span style=\"color:#ffee99;\">&quot;https://example.com&quot;</span><span style=\"color:#f8f8f2;\">,\n</span><span style=\"color:#f8f8f2;\">        onclick: |</span><span style=\"font-style:italic;color:#fd971f;\">evt</span><span style=\"color:#f8f8f2;\">| {{\n</span><span style=\"color:#f8f8f2;\">            evt.</span><span style=\"color:#66d9ef;\">prevent_default</span><span style=\"color:#f8f8f2;\">();\n</span><span style=\"color:#f8f8f2;\">            log::info</span><span style=\"color:#f92672;\">!</span><span style=\"color:#f8f8f2;\">(</span><span style=\"color:#ffee99;\">&quot;link clicked&quot;</span><span style=\"color:#f8f8f2;\">)\n</span><span style=\"color:#f8f8f2;\">        }},\n</span><span style=\"color:#f8f8f2;\">        </span><span style=\"color:#ffee99;\">&quot;example.com&quot;\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
+            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f8f8f2;\">rsx! {{\n</span><span style=\"color:#f8f8f2;\">    a {{\n</span><span style=\"color:#f8f8f2;\">        href: </span><span style=\"color:#ffee99;\">&quot;https://example.com&quot;</span><span style=\"color:#f8f8f2;\">,\n</span><span style=\"color:#f8f8f2;\">        prevent_default: </span><span style=\"color:#ffee99;\">&quot;onclick&quot;</span><span style=\"color:#f8f8f2;\">,\n</span><span style=\"color:#f8f8f2;\">        </span><span style=\"color:#ffee99;\">&quot;example.com&quot;\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
             name: "event_click.rs".to_string(),
         }
         DemoFrame { event_prevent_default::App {} }
@@ -11909,7 +11909,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 ": A Render that Runs Dioxus applications natively, but renders them with the system webview. This is currently a copy of the desktop render"
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/Web",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/web",
                     "Web"
                 }
                 ": Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM"
@@ -12005,7 +12005,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 }
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx",
                     "RSX"
                 }
                 ": The core parsing for RSX used for hot reloading, autoformatting, and the macro"
@@ -12085,7 +12085,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 ": Formats RSX code"
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX-rosetta",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx-rosetta",
                     "rsx-rosetta"
                 }
                 ": Handles conversion between HTML and RSX"

--- a/src/docs/router_06.rs
+++ b/src/docs/router_06.rs
@@ -9501,7 +9501,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 ": A Render that Runs Dioxus applications natively, but renders them with the system webview. This is currently a copy of the desktop render"
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/Web",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/web",
                     "Web"
                 }
                 ": Renders Dioxus applications in the browser by compiling to WASM and manipulating the DOM"
@@ -9595,7 +9595,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 }
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx",
                     "RSX"
                 }
                 ": The core parsing for RSX used for hot reloading, autoformatting, and the macro"
@@ -9659,7 +9659,7 @@ pub fn ContributingProjectStructure() -> dioxus::prelude::Element {
                 ": Formats RSX code"
             }
             li {
-                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/RSX-rosetta",
+                a { href: "https://github.com/DioxusLabs/dioxus/tree/main/packages/rsx-rosetta",
                     "rsx-rosetta"
                 }
                 ": Handles conversion between HTML and RSX"


### PR DESCRIPTION
This PR documents the new functionality of event handlers. It removes the section added in https://github.com/DioxusLabs/docsite/pull/275 in the 0.6 guide now that event handlers can accept futures directly. It also introduces Callbacks and fixes the 0.5 guide referencing the 0.6 version of prevent default