### PR TITLE
Fix the instructions to set up tailwind with dioxus 0.6

### DIFF
--- a/docs-src/0.6/src/cookbook/tailwind.md
+++ b/docs-src/0.6/src/cookbook/tailwind.md
@@ -49,13 +49,7 @@ module.exports = {
 @tailwind utilities;
 ```
 
-7. Add [Manganis](https://github.com/DioxusLabs/manganis) to your project to handle asset collection.
-
-```sh
-cargo add manganis
-```
-
-8. Create a link to the `tailwind.css` file using manganis somewhere in your rust code:
+7. Create a link to the `tailwind.css` file using manganis somewhere in your rust code:
 
 ```rust
 {{#include src/doc_examples/tailwind.rs}}
@@ -78,7 +72,7 @@ cargo add manganis
 - Run the following command in the root of the project to start the tailwind css compiler:
 
 ```bash
-npx tailwindcss -i ./input.css -o ./public/tailwind.css --watch
+npx tailwindcss -i ./input.css -o ./assets/tailwind.css --watch
 ```
 
 ### Web

--- a/src/doc_examples/tailwind.rs
+++ b/src/doc_examples/tailwind.rs
@@ -1,4 +1,12 @@
 use dioxus::prelude::*;
 
-// Urls are relative to your Cargo.toml file
-const TAILWIND_URL: Asset = asset!("/assets/tailwind.css");
+#[component]
+fn app() -> Element {
+    rsx! {
+        // The style component inserts a style link into the head of the document
+        document::Style {
+            // Urls are relative to your Cargo.toml file
+            href: asset!("/assets/tailwind.css")
+        }
+    }
+}


### PR DESCRIPTION
The 0.6 docs were using the old way of importing css into the head. This PR updates the documentation to use the head elements instead