### PR TITLE
Update asset documentation

### DIFF
--- a/docs-src/0.5/src/reference/desktop/index.md
+++ b/docs-src/0.5/src/reference/desktop/index.md
@@ -33,7 +33,7 @@ For these cases, Dioxus desktop exposes the use_eval hook that allows you to run
 You can link to local assets in dioxus desktop instead of using a url:
 
 ```rust
-{{#include src/doc_examples/custom_assets.rs}}
+{{#include src/doc_examples/untested_05/custom_assets.rs}}
 ```
 
 You can read more about assets in the [assets](./assets.md) reference.

--- a/docs-src/0.5/src/reference/mobile/apis.md
+++ b/docs-src/0.5/src/reference/mobile/apis.md
@@ -18,7 +18,7 @@ For these cases, Dioxus desktop exposes the use_eval hook that allows you to run
 You can link to local assets in dioxus mobile instead of using a url:
 
 ```rust
-{{#include src/doc_examples/custom_assets.rs}}
+{{#include src/doc_examples/untested_05/custom_assets.rs}}
 ```
 
 ## Integrating with Wry

--- a/docs-src/0.6/src/cookbook/optimizing.md
+++ b/docs-src/0.6/src/cookbook/optimizing.md
@@ -142,4 +142,4 @@ Obviously, not all of them are just about performance, but some of them are.
 
 ## Optimizing the size of assets
 
-Assets can be a significant part of your app's size. Dioxus includes alpha support for first party [assets](../reference/assets.md). Any assets you include with the `mg!` macro will be optimized for production in release builds.
+Assets can be a significant part of your app's size. Dioxus includes alpha support for first party [assets](../reference/assets.md). Any assets you include with the `asset!` macro will be optimized for production in release builds.

--- a/docs-src/0.6/src/guides/assets.md
+++ b/docs-src/0.6/src/guides/assets.md
@@ -1,26 +1,18 @@
 # Assets
 
-> ⚠️ Support: Manganis is currently in alpha. API changes are planned and bugs are more likely
-
 Assets are files that are included in the final build of the application. They can be images, fonts, stylesheets, or any other file that is not a source file. Dioxus includes first class support for assets, and provides a simple way to include them in your application and automatically optimize them for production.
 
 Assets in dioxus are also compatible with libraries! If you are building a library, you can include assets in your library and they will be automatically included in the final build of any application that uses your library.
 
-First, you need to add the `manganis` crate to your `Cargo.toml` file:
-
-```sh
-cargo add manganis
-```
-
 ## Including images
 
-To include an asset in your application, you can simply wrap the path to the asset in a `mg!` call. For example, to include an image in your application, you can use the following code:
+To include an asset in your application, you can simply wrap the path to the asset in the `asset!` macro. For example, to include an image in your application, you can use the following code:
 
 ```rust
 {{#include src/doc_examples/assets.rs:images}}
 ```
 
-You can also optimize, resize, and preload images using the `mg!` macro. Choosing an optimized file type (like WebP) and a reasonable quality setting can significantly reduce the size of your images which helps your application load faster. For example, you can use the following code to include an optimized image in your application:
+You can also optimize, resize, and preload images using the `asset!` macro. Choosing an optimized file type (like Avif) and a reasonable quality setting can significantly reduce the size of your images which helps your application load faster. For example, you can use the following code to include an optimized image in your application:
 
 ```rust
 {{#include src/doc_examples/assets.rs:optimized_images}}
@@ -28,7 +20,7 @@ You can also optimize, resize, and preload images using the `mg!` macro. Choosin
 
 ## Including arbitrary files
 
-In dioxus desktop, you may want to include a file with data for your application. You can use the `file` function to include arbitrary files in your application. For example, you can use the following code to include a file in your application:
+In dioxus desktop, you may want to include a file with data for your application. If you don't set any options for your asset and the file extension is not recognized, the asset will be copied without any changes. For example, you can use the following code to include a binary file in your application:
 
 ```rust
 {{#include src/doc_examples/assets.rs:arbitrary_files}}
@@ -38,7 +30,7 @@ These files will be automatically included in the final build of your applicatio
 
 ## Including stylesheets
 
-You can include stylesheets in your application using the `mg!` macro. For example, you can use the following code to include a stylesheet in your application:
+You can include stylesheets in your application using the `asset!` macro. Stylesheets will automatically be minified as they are bundled to speed up load times. For example, you can use the following code to include a stylesheet in your application:
 
 ```rust
 {{#include src/doc_examples/assets.rs:style_sheets}}
@@ -50,4 +42,4 @@ You can include stylesheets in your application using the `mg!` macro. For examp
 
 Dioxus provides first class support for assets, and makes it easy to include them in your application. You can include images, arbitrary files, and stylesheets in your application, and dioxus will automatically optimize them for production. This makes it easy to include assets in your application and ensure that they are optimized for production.
 
-You can read more about assets and all the options available to optimize your assets in the [manganis documentation](https://docs.rs/manganis/0.2.2/manganis/).
+You can read more about assets and all the options available to optimize your assets in the [manganis documentation](https://docs.rs/manganis/0.6.0/manganis).

--- a/src/components/playground.rs
+++ b/src/components/playground.rs
@@ -15,5 +15,5 @@ const BUILT_URL: &str = "http://localhost:3000/built/";
 #[component]
 pub fn Playground() -> Element {
     // dioxus_playground::Playground { socket_url: SOCKET_URL, built_url: BUILT_URL }
-    rsx! {  }
+    rsx! {}
 }

--- a/src/doc_examples/assets.rs
+++ b/src/doc_examples/assets.rs
@@ -12,16 +12,16 @@ fn App() -> Element {
 }
 /// ANCHOR_END: images
 
-// manganis::mg!(image("./assets/static/enum_router.png")
-//         // Manganis uses the builder pattern inside the macro. You can set the image size in pixels at compile time to send the smallest possible image to the client
-//         .size(52, 52)
-//         // You can also convert the image to a web friendly format at compile time. This can make your images significantly smaller
-//         .format(ImageType::Avif)
-//         // You can even tell manganis to preload the image so it's ready to be displayed as soon as it's needed
-//         .preload());
-
 /// ANCHOR: optimized_images
-pub const ENUM_ROUTER_IMG: Asset = asset!("/assets/static/enum_router.png");
+pub const ENUM_ROUTER_IMG: Asset = asset!(
+    "/assets/static/enum_router.png",
+    // You can pass a second argument to the asset macro to set up options for the asset
+    ImageAssetOptions::new()
+        // You can set the image size in pixels at compile time to send the smallest possible image to the client
+        .with_size(ImageSize::Manual { width: 52, height: 52 })
+        // You can also convert the image to a web friendly format at compile time. This can make your images significantly smaller
+        .with_format(ImageFormat::Avif)
+);
 
 fn EnumRouter() -> Element {
     rsx! {

--- a/src/doc_examples/untested_05/custom_assets.rs
+++ b/src/doc_examples/untested_05/custom_assets.rs
@@ -7,7 +7,7 @@ fn main() {
 fn app() -> Element {
     rsx! {
         div {
-            img { src: asset!("/assets/static/scanner.png") } 
+            img { src: "/public/static/scanner.png" }
         }
     }
 }

--- a/src/docs/router_06.rs
+++ b/src/docs/router_06.rs
@@ -6355,9 +6355,9 @@ pub fn GuidesAssets() -> dioxus::prelude::Element {
             a { href: "#including-images", class: "header", "Including images" }
         }
         p {
-            "To include an asset in your application, you can simply wrap the path to the asset in a  "
-            code { "mg!" }
-            " call. For example, to include an image in your application, you can use the following code:"
+            "To include an asset in your application, you can simply wrap the path to the asset in the  "
+            code { "asset!" }
+            " macro. For example, to include an image in your application, you can use the following code:"
         }
         CodeBlock {
             contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f92672;\">use </span><span style=\"color:#f8f8f2;\">dioxus::prelude::</span><span style=\"color:#f92672;\">*</span><span style=\"color:#f8f8f2;\">;\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">App</span><span style=\"color:#f8f8f2;\">() -&gt; Element {{\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#8c8c8c;\">// You can link to assets that are relative to the package root or even link to an asset from a url\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#8c8c8c;\">// These assets will automatically be picked up by the dioxus cli, optimized, and bundled with your final applications\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"font-style:italic;color:#66d9ef;\">const </span><span style=\"color:#ff80f4;\">ASSET</span><span style=\"color:#f8f8f2;\">: Asset </span><span style=\"color:#f92672;\">= </span><span style=\"color:#f8f8f2;\">asset!(</span><span style=\"color:#ffee99;\">&quot;/assets/static/ferrous_wave.png&quot;</span><span style=\"color:#f8f8f2;\">);\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"color:#f8f8f2;\">    rsx! {{\n</span><span style=\"color:#f8f8f2;\">        img {{ src: </span><span style=\"color:#ffee99;\">&quot;{{ASSET}}&quot; </span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
@@ -6365,20 +6365,18 @@ pub fn GuidesAssets() -> dioxus::prelude::Element {
         }
         p {
             "You can also optimize, resize, and preload images using the  "
-            code { "mg!" }
-            " macro. Choosing an optimized file type (like WebP) and a reasonable quality setting can significantly reduce the size of your images which helps your application load faster. For example, you can use the following code to include an optimized image in your application:"
+            code { "asset!" }
+            " macro. Choosing an optimized file type (like Avif) and a reasonable quality setting can significantly reduce the size of your images which helps your application load faster. For example, you can use the following code to include an optimized image in your application:"
         }
         CodeBlock {
-            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f92672;\">pub </span><span style=\"font-style:italic;color:#66d9ef;\">const </span><span style=\"color:#ff80f4;\">ENUM_ROUTER_IMG</span><span style=\"color:#f8f8f2;\">: Asset </span><span style=\"color:#f92672;\">= </span><span style=\"color:#f8f8f2;\">asset!(</span><span style=\"color:#ffee99;\">&quot;/assets/static/enum_router.png&quot;</span><span style=\"color:#f8f8f2;\">);\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">EnumRouter</span><span style=\"color:#f8f8f2;\">() -&gt; Element {{\n</span><span style=\"color:#f8f8f2;\">    rsx! {{\n</span><span style=\"color:#f8f8f2;\">        img {{ src: </span><span style=\"color:#ffee99;\">&quot;{{ENUM_ROUTER_IMG}}&quot; </span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
+            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f92672;\">pub </span><span style=\"font-style:italic;color:#66d9ef;\">const </span><span style=\"color:#ff80f4;\">ENUM_ROUTER_IMG</span><span style=\"color:#f8f8f2;\">: Asset </span><span style=\"color:#f92672;\">= </span><span style=\"color:#f8f8f2;\">asset!(\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#ffee99;\">&quot;/assets/static/enum_router.png&quot;</span><span style=\"color:#f8f8f2;\">,\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#8c8c8c;\">// You can pass a second argument to the asset macro to set up options for the asset\n</span><span style=\"color:#f8f8f2;\">    ImageAssetOptions::new()\n</span><span style=\"color:#f8f8f2;\">        </span><span style=\"color:#8c8c8c;\">// You can set the image size in pixels at compile time to send the smallest possible image to the client\n</span><span style=\"color:#f8f8f2;\">        .</span><span style=\"color:#66d9ef;\">with_size</span><span style=\"color:#f8f8f2;\">(ImageSize::Manual {{ width: </span><span style=\"color:#ff80f4;\">52</span><span style=\"color:#f8f8f2;\">, height: </span><span style=\"color:#ff80f4;\">52 </span><span style=\"color:#f8f8f2;\">}})\n</span><span style=\"color:#f8f8f2;\">        </span><span style=\"color:#8c8c8c;\">// You can also convert the image to a web friendly format at compile time. This can make your images significantly smaller\n</span><span style=\"color:#f8f8f2;\">        .</span><span style=\"color:#66d9ef;\">with_format</span><span style=\"color:#f8f8f2;\">(ImageFormat::Avif)\n</span><span style=\"color:#f8f8f2;\">);\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">EnumRouter</span><span style=\"color:#f8f8f2;\">() -&gt; Element {{\n</span><span style=\"color:#f8f8f2;\">    rsx! {{\n</span><span style=\"color:#f8f8f2;\">        img {{ src: </span><span style=\"color:#ffee99;\">&quot;{{ENUM_ROUTER_IMG}}&quot; </span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
             name: "assets.rs".to_string(),
         }
         h2 { id: "including-arbitrary-files",
             a { href: "#including-arbitrary-files", class: "header", "Including arbitrary files" }
         }
         p {
-            "In dioxus desktop, you may want to include a file with data for your application. You can use the  "
-            code { "file" }
-            " function to include arbitrary files in your application. For example, you can use the following code to include a file in your application:"
+            "In dioxus desktop, you may want to include a file with data for your application. If you don't set any options for your asset and the file extension is not recognized, the asset will be copied without any changes. For example, you can use the following code to include a binary file in your application:"
         }
         CodeBlock {
             contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#8c8c8c;\">// You can also collect arbitrary files. Relative paths are resolved relative to the package root\n</span><span style=\"font-style:italic;color:#66d9ef;\">const </span><span style=\"color:#ff80f4;\">PATH_TO_BUNDLED_CARGO_TOML</span><span style=\"color:#f8f8f2;\">: Asset </span><span style=\"color:#f92672;\">= </span><span style=\"color:#f8f8f2;\">asset!(</span><span style=\"color:#ffee99;\">&quot;/Cargo.toml&quot;</span><span style=\"color:#f8f8f2;\">);</span></pre>\n",
@@ -6392,8 +6390,8 @@ pub fn GuidesAssets() -> dioxus::prelude::Element {
         }
         p {
             "You can include stylesheets in your application using the  "
-            code { "mg!" }
-            " macro. For example, you can use the following code to include a stylesheet in your application:"
+            code { "asset!" }
+            " macro. Stylesheets will automatically be minified as they are bundled to speed up load times. For example, you can use the following code to include a stylesheet in your application:"
         }
         CodeBlock {
             contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#8c8c8c;\">// You can also bundle stylesheets with your application\n</span><span style=\"color:#8c8c8c;\">// Any files that end with .css will be minified and bundled with your application even if you don&#39;t explicitly include them in your &lt;head&gt;\n</span><span style=\"font-style:italic;color:#66d9ef;\">const </span><span style=\"color:#f92672;\">_</span><span style=\"color:#f8f8f2;\">: Asset </span><span style=\"color:#f92672;\">= </span><span style=\"color:#f8f8f2;\">asset!(</span><span style=\"color:#ffee99;\">&quot;/tailwind.css&quot;</span><span style=\"color:#f8f8f2;\">);</span></pre>\n",
@@ -6414,7 +6412,7 @@ pub fn GuidesAssets() -> dioxus::prelude::Element {
         }
         p {
             "You can read more about assets and all the options available to optimize your assets in the "
-            a { href: "https://docs.rs/manganis/0.2.2/manganis/", "manganis documentation" }
+            a { href: "https://docs.rs/manganis/0.6.0/manganis", "manganis documentation" }
             "."
         }
     }
@@ -8748,7 +8746,7 @@ pub fn CookbookOptimizing() -> dioxus::prelude::Element {
             "Assets can be a significant part of your app's size. Dioxus includes alpha support for first party "
             a { href: "../reference/assets", "assets" }
             ". Any assets you include with the "
-            code { "mg!" }
+            code { "asset!" }
             " macro will be optimized for production in release builds."
         }
     }

--- a/src/docs/router_06.rs
+++ b/src/docs/router_06.rs
@@ -6332,25 +6332,12 @@ pub fn GuidesAssets() -> dioxus::prelude::Element {
         h1 { id: "assets",
             a { href: "#assets", class: "header", "Assets" }
         }
-        blockquote {
-            p {
-                "⚠\u{fe0f} Support: Manganis is currently in alpha. API changes are planned and bugs are more likely"
-            }
-        }
         p {
             "Assets are files that are included in the final build of the application. They can be images, fonts, stylesheets, or any other file that is not a source file. Dioxus includes first class support for assets, and provides a simple way to include them in your application and automatically optimize them for production."
         }
         p {
             "Assets in dioxus are also compatible with libraries! If you are building a library, you can include assets in your library and they will be automatically included in the final build of any application that uses your library."
         }
-        p {
-            "First, you need to add the  "
-            code { "manganis" }
-            " crate to your  "
-            code { "Cargo.toml" }
-            " file:"
-        }
-        CodeBlock { contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f8f8f2;\">cargo add manganis</span></pre>\n" }
         h2 { id: "including-images",
             a { href: "#including-images", class: "header", "Including images" }
         }
@@ -6603,7 +6590,7 @@ pub fn GuidesDesktopIndex() -> dioxus::prelude::Element {
         }
         p { "You can link to local assets in dioxus desktop instead of using a url:" }
         CodeBlock {
-            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f92672;\">use </span><span style=\"color:#f8f8f2;\">dioxus::prelude::</span><span style=\"color:#f92672;\">*</span><span style=\"color:#f8f8f2;\">;\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">main</span><span style=\"color:#f8f8f2;\">() {{\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#66d9ef;\">launch</span><span style=\"color:#f8f8f2;\">(app);\n</span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">app</span><span style=\"color:#f8f8f2;\">() -&gt; Element {{\n</span><span style=\"color:#f8f8f2;\">    rsx! {{\n</span><span style=\"color:#f8f8f2;\">        div {{\n</span><span style=\"color:#f8f8f2;\">            img {{ src: </span><span style=\"color:#ffee99;\">&quot;/public/static/scanner.png&quot; </span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">        }}\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
+            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f92672;\">use </span><span style=\"color:#f8f8f2;\">dioxus::prelude::</span><span style=\"color:#f92672;\">*</span><span style=\"color:#f8f8f2;\">;\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">main</span><span style=\"color:#f8f8f2;\">() {{\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#66d9ef;\">launch</span><span style=\"color:#f8f8f2;\">(app);\n</span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">app</span><span style=\"color:#f8f8f2;\">() -&gt; Element {{\n</span><span style=\"color:#f8f8f2;\">    rsx! {{\n</span><span style=\"color:#f8f8f2;\">        div {{\n</span><span style=\"color:#f8f8f2;\">            img {{ src: asset!(</span><span style=\"color:#ffee99;\">&quot;/assets/static/scanner.png&quot;</span><span style=\"color:#f8f8f2;\">) }} \n</span><span style=\"color:#f8f8f2;\">        }}\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
             name: "custom_assets.rs".to_string(),
         }
         p {
@@ -6930,7 +6917,7 @@ pub fn GuidesMobileApis() -> dioxus::prelude::Element {
         }
         p { "You can link to local assets in dioxus mobile instead of using a url:" }
         CodeBlock {
-            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f92672;\">use </span><span style=\"color:#f8f8f2;\">dioxus::prelude::</span><span style=\"color:#f92672;\">*</span><span style=\"color:#f8f8f2;\">;\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">main</span><span style=\"color:#f8f8f2;\">() {{\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#66d9ef;\">launch</span><span style=\"color:#f8f8f2;\">(app);\n</span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">app</span><span style=\"color:#f8f8f2;\">() -&gt; Element {{\n</span><span style=\"color:#f8f8f2;\">    rsx! {{\n</span><span style=\"color:#f8f8f2;\">        div {{\n</span><span style=\"color:#f8f8f2;\">            img {{ src: </span><span style=\"color:#ffee99;\">&quot;/public/static/scanner.png&quot; </span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">        }}\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
+            contents: "<pre style=\"background-color:#0d0d0d;\">\n<span style=\"color:#f92672;\">use </span><span style=\"color:#f8f8f2;\">dioxus::prelude::</span><span style=\"color:#f92672;\">*</span><span style=\"color:#f8f8f2;\">;\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">main</span><span style=\"color:#f8f8f2;\">() {{\n</span><span style=\"color:#f8f8f2;\">    </span><span style=\"color:#66d9ef;\">launch</span><span style=\"color:#f8f8f2;\">(app);\n</span><span style=\"color:#f8f8f2;\">}}\n</span><span style=\"color:#f8f8f2;\">\n</span><span style=\"font-style:italic;color:#66d9ef;\">fn </span><span style=\"color:#a6e22e;\">app</span><span style=\"color:#f8f8f2;\">() -&gt; Element {{\n</span><span style=\"color:#f8f8f2;\">    rsx! {{\n</span><span style=\"color:#f8f8f2;\">        div {{\n</span><span style=\"color:#f8f8f2;\">            img {{ src: asset!(</span><span style=\"color:#ffee99;\">&quot;/assets/static/scanner.png&quot;</span><span style=\"color:#f8f8f2;\">) }} \n</span><span style=\"color:#f8f8f2;\">        }}\n</span><span style=\"color:#f8f8f2;\">    }}\n</span><span style=\"color:#f8f8f2;\">}}</span></pre>\n",
             name: "custom_assets.rs".to_string(),
         }
         h2 { id: "integrating-with-wry",


### PR DESCRIPTION
Some of the asset documentation pointed to an older version of the manganis crate with a different syntax for asset optimization. This PR fixes that issue