### PR TITLE
Minor adjustments to make the new HotDog-tutorial more coherent.

### DIFF
--- a/docs-src/0.6/src/guide/new_app.md
+++ b/docs-src/0.6/src/guide/new_app.md
@@ -19,9 +19,10 @@ You'll need to select a template to use to get started.
 
 We're going to use the bare-bones template for *HotDog*. Our app won't be too complex and can fit in one file.
 
-- Select web as the default platform
+- Select "false" when asked if you want to create a fullstack website.
 - Select "false" for the router, though we *will* eventually add the router to the app.
 - Select no for TailwindCSS. If you want to use Tailwind, make sure to read the [TailwindCSS guide](../cookbook/tailwind.md).
+- Select "Web" as the default platform.
 
 > 📣 You don't need `dx new` to create new Dioxus apps! Dioxus apps are Rust projects and can also be built with tools like cargo.
 

--- a/docs-src/0.6/src/guide/state.md
+++ b/docs-src/0.6/src/guide/state.md
@@ -4,12 +4,12 @@ Now that our *HotDog* app is scaffolded and styled, we can finally add some inte
 
 ## Encapsulating State
 
-Before we get too far, let's split our app into two parts: the `NavBar` and the `DogView`. This will help us organize our app and keep the `DogView` state separated from `NavBar` state.
+Before we get too far, let's split our app into two parts: the `Title` and the `DogView`. This will help us organize our app and keep the `DogView` state separated from `Title` state.
 
 ```rust
 fn App() -> Element {
     rsx! {
-        NavBar {}
+        Title {}
         DogView {}
     }
 }

--- a/docs-src/0.6/src/guide/state.md
+++ b/docs-src/0.6/src/guide/state.md
@@ -117,7 +117,7 @@ struct TitleState(String);
 
 fn App() -> Element {
     // Provide that type as a Context
-    use_context_provider(|| TitleState("HotDog".to_string()))
+    use_context_provider(|| TitleState("HotDog".to_string()));
     rsx! {
         Title {}
     }


### PR DESCRIPTION
The new tutorial greatly improves the onboarding experience. I have found a few minor inconsistencies for which this pull request suggests possible solutions:

- state.md: Added a missing semicolon.
- state.md: Replace `NavBar` with `Title`, as the rest of the example assumes `Title` but not `NavBar`.
- new_app.md: Analogous to the video example: add fullstack = false and order points as they are in the `dx` interface.