### PR TITLE
A few more minor adjustments to make the HotDog-tutorial more coherent.

### DIFF
--- a/docs-src/0.6/src/guide/assets.md
+++ b/docs-src/0.6/src/guide/assets.md
@@ -163,8 +163,9 @@ html, body {
     color: white;
 }
 
-#heart {
+a#heart {
     background-color: white;
+    color: red;
     padding: 5px;
     border-radius: 5px;
 }

--- a/docs-src/0.6/src/guide/assets.md
+++ b/docs-src/0.6/src/guide/assets.md
@@ -35,7 +35,7 @@ static CSS: Asset = asset!("/assets/main.css");
 We also need to load the asset into our app using the `document::Stylesheet` component. This component is equivalent to the `<link>` HTML element but also ensures the CSS will be pre-loaded during server-side-rendering.
 
 ```rust
-fn app() -> Element {
+fn App() -> Element {
     rsx! {
         document::Stylesheet { href: CSS }
         // rest of the app

--- a/docs-src/0.6/src/guide/backend.md
+++ b/docs-src/0.6/src/guide/backend.md
@@ -82,7 +82,7 @@ async fn launch(config: Config, app: Component<()>) {
 
     // start server
     axum::serve(listener, router).await
-}a
+}
 ```
 
 As of Dioxus 0.6, we only support the `axum` server framework. We plan to build additional server features in the future and  only support `axum` to ship faster.
@@ -235,6 +235,7 @@ fn DogView() -> Element {
         div { id: "buttons",
             // ...
             button {
+                id: "save",
                 onclick: move |_| async move {
                     // Clone the current image
                     let current = img_src.cloned().unwrap();

--- a/docs-src/0.6/src/guide/bundle.md
+++ b/docs-src/0.6/src/guide/bundle.md
@@ -137,7 +137,7 @@ We should receive a series of INFO traces from the CLI as it builds, and then fi
 
 We can manually run the server simply by executing it. If you're using a default `dioxus::launch` setup, then the server will read the `IP` and `PORT` environment variables to serve.
 
-> 📣 If you intend to serve from within a container (eg Docker), then you need to override the default `127.0.0.1` address with `IP=0.0.0.0` to listen for external connections.
+> 📣 If you intend to serve from within a container (e.g., Docker), then you need to override the default `127.0.0.1` address with `IP=0.0.0.0` to listen for external connections.
 
 ![Serving the server](/assets/06_docs/serving_server.png)
 

--- a/docs-src/0.6/src/guide/data_fetching.md
+++ b/docs-src/0.6/src/guide/data_fetching.md
@@ -49,6 +49,7 @@ Dioxus has stellar support for asynchronous Rust. We can simply convert our `onc
 The changes to our code are quite simple - just add the `reqwest::get` call and then call `.set()` on `img_src` with the result.
 
 ```rust
+#[component]
 fn DogView() -> Element {
     let mut img_src = use_signal(|| "".to_string());
 
@@ -63,11 +64,14 @@ fn DogView() -> Element {
         img_src.set(response.message);
     };
 
+    // ..
+
     rsx! {
         div { id: "dogview",
             img { src: "{img_src}" }
         }
         div { id: "buttons",
+            // ..
             button { onclick: fetch_new, id: "save", "save!" }
         }
     }
@@ -99,6 +103,7 @@ In Dioxus, *Resources* are pieces of state whose value is dependent on the compl
 Let's change our component to use a resource instead:
 
 ```rust
+#[component]
 fn DogView() -> Element {
     let mut img_src = use_resource(|| async move {
         reqwest::get("https://dog.ceo/api/breeds/image/random")
@@ -115,6 +120,7 @@ fn DogView() -> Element {
             img { src: img_src.cloned().unwrap_or_default() }
         }
         div { id: "buttons",
+            button { onclick: move |_| img_src.restart(), id: "skip", "skip" }
             button { onclick: move |_| img_src.restart(), id: "save", "save!" }
         }
     }

--- a/docs-src/0.6/src/guide/new_app.md
+++ b/docs-src/0.6/src/guide/new_app.md
@@ -80,7 +80,7 @@ All Dioxus apps will include `dioxus` as a dependency:
 dioxus = { version = "0.6.0" }
 ```
 
-The prebuilt Dioxus templates initialize different cargo features for your app. `dx` will use these to decide what cargo features to enable when you specify the `--platform` feature. For example, when building your app for desktop, `dx` will call `cargo build --no-default-features --features desktop`.
+The prebuilt Dioxus templates initialize different cargo features for your app. `dx` will use these to decide which cargo features to enable when you specify the `--platform` feature. For example, if you use `dx serve --platform desktop` to build your app for desktop, `dx` will call `cargo build --no-default-features --features desktop`.
 
 ```toml
 [features]

--- a/docs-src/0.6/src/guide/routing.md
+++ b/docs-src/0.6/src/guide/routing.md
@@ -103,7 +103,7 @@ fn app() -> Element {
     rsx! {
         document::Stylesheet { href: asset!("/assets/main.css") }
 
-        // 📣 delete DogView and replace it with the Router component.
+        // 📣 delete Title and DogView and replace it with the Router component.
         Router::<Route> {}
     }
 }
@@ -125,16 +125,16 @@ enum Route {
 
 Note here that the `PageNotFound` route takes the "segments" parameter. Dioxus routes are not only type-safe as variants, but also type-safe with URL parameters. For more information on how this works, [check the router guide](../router/index.md).
 
-At this point, we should see our app, but this time without its NavBar.
+At this point, we should see our app, but this time without its Title.
 
 ![No Navbar](/assets/06_docs/no_navbar.png)
 
 
 ## Rendering the NavBar with a Layout
 
-We're rendering our DogView component, but unfortunately we no longer see our title Navbar. Let's add that back!
+We're rendering our DogView component, but unfortunately we no longer see our Title. Let's add that back and turn it into a NavBar!
 
-In our `src/components/nav.rs` file, we'll add back our NavBar code, but this time with two new items: the `Link {}` and `Outlet` components:
+In our `src/components/nav.rs` file, we'll add back our Title code, but rename it to NavBar and modify it with two new items: the `Link {}` and `Outlet` components.
 
 ```rust
 use crate::Route;

--- a/docs-src/0.6/src/guide/routing.md
+++ b/docs-src/0.6/src/guide/routing.md
@@ -15,8 +15,7 @@ We generally recommend splitting your components, models, and backend functional
 ```sh
 ├── Cargo.toml
 ├── assets
-│   ├── main.css
-│   └── screenshot.png
+│   └── main.css
 └── src
     ├── backend.rs
     ├── components
@@ -41,11 +40,29 @@ pub use nav::*;
 pub use view::*;
 ```
 
+Finally, we need to bring `backend` and `components` into scope in our `main.rs` file:
+
+```rust
+mod components;
+mod backend;
+
+use crate::components::*;
+```
+
+For more information on organizing Rust projects with modules, see the [Modules section](https://doc.rust-lang.org/book/ch07-02-defining-modules-to-control-scope-and-privacy.html) of the Rust Book.
+
 ## Creating a Route
 
 Most Dioxus apps you'll build will have different screens. This could include pages like *Login*, *Settings*, and *Profile*. Our HotDog app will have two screens: a *DogView* page and a *Favorites* page.
 
-Dioxus provides a first-party router that natively integrates with web, desktop, and mobile. For example, on web, whenever you visit the `/favorites` url in your browser, the corresponding *Favorites* page will load. The Dioxus router is very powerful, and most importantly, type-safe. You can rest easy knowing that users will never be sent to an invalid route. To achieve, this, the Dioxus router is defined as an enum with the `Routable` derive attribute:
+Dioxus provides a first-party router that natively integrates with web, desktop, and mobile. For example, on web, whenever you visit the `/favorites` url in your browser, the corresponding *Favorites* page will load. The Dioxus router is very powerful, and most importantly, type-safe. You can rest easy knowing that users will never be sent to an invalid route. To achieve this, we first need to add the "Router" feature to the Cargo.toml file:
+
+```toml
+[dependencies]
+dioxus = { version = "0.6.0", features = ["fullstack", "router"] } # <----- add "router"
+```
+
+Next, the Dioxus router is defined as an enum with the `Routable` derive attribute:
 
 ```rust
 #[derive(Routable, Clone, PartialEq)]

--- a/docs-src/0.6/src/guide/routing.md
+++ b/docs-src/0.6/src/guide/routing.md
@@ -84,15 +84,6 @@ enum Route {
 fn DogView() -> Element { /* */ }
 ```
 
-To use a different component, we can specify the path manually with an additional parameter.
-
-```rust
-#[derive(Routable, Clone, PartialEq)]
-enum Route {
-    #[route("/", components::AppView)] // <---- an AppView component must exist
-    DogView,
-}
-```
 
 ## Rendering the Route
 

--- a/docs-src/0.6/src/guide/state.md
+++ b/docs-src/0.6/src/guide/state.md
@@ -7,8 +7,10 @@ Now that our *HotDog* app is scaffolded and styled, we can finally add some inte
 Before we get too far, let's split our app into two parts: the `Title` and the `DogView`. This will help us organize our app and keep the `DogView` state separated from `Title` state.
 
 ```rust
+#[component]
 fn App() -> Element {
     rsx! {
+        document::Stylesheet { href: CSS }
         Title {}
         DogView {}
     }
@@ -74,6 +76,8 @@ When called in a component, the `use_hook` function will return a `.clone()` of 
 ```rust
 fn DogView() -> Element {
     let img_src = use_hook(|| "https://images.dog.ceo/breeds/pitbull/dog-3981540_1280.jpg");
+
+    // ..
 
     rsx! {
         div { id: "dogview",


### PR DESCRIPTION
I have a few additional suggestions for the HotDog tutorial that I hope will contribute to a better onboarding experience for new dioxus users.

- assets.md: 
    - `fn app()` has been changed to `fn App()` to be consistent with other examples.
    - `#heart` -> `a#heart` and add `color:red;`: On a Linux machine I tested this on, this change was necessary to see the red heart. Otherwise the heart (`Link { to: Route::Favorites, id: "heart", "♥️" }`) was just a normal character, not an emoji as in the screenshots, and therefore inherited the white font color on a white background. Changing the color to red made it visible on the white background.
- backend.md: removed a trailing from `a`: from `}a` to `}`
- bundle.md: change `(eg` to `(e.g.,`, e.g., for improved screen reader support.
- data_fetching.md: 
    - Added `// ..` to indicate that some code has been omitted from the example.
    - Added `#[component]` as it is also included in similar example blocks.
    - Added `skip` button as it is assumed to be present in later code blocks.
- state.md: 
    - Added document stylesheet so that users can easily copy the code block.
    - Added `// ..` to indicate that some code was omitted from the example.
- new_app.md: New users may not know that `dx serve` or `dx build` needs to be written in front of `--platform`. I added this context.
- routing.md:
    - remove: `│   └── screenshot.png` as this file will not exist if you follow the tutorial.
    - Many sections of the tutorial seem to be aimed at people without an extensive Rust background. Therefore, I have added a section on bringing the `backend` and `components` into the scope of the `main.rs` file. I hope this will make the reorganization part of the tutorial easier to follow for beginners.
    - I would also suggest including a part that adds the router to the Cargo.toml file, as this is a necessary prerequisite for Routable in the example below.
    - I found the [`#[route("/", components::AppView)]` example](https://github.com/DioxusLabs/docsite/blob/ca57b044706c3953b159b2ba8d30e280cf5ed3ea/docs-src/0.6/src/guide/routing.md?plain=1#L72) a bit confusing: Why is `DogView` still in there if it is not rendered? It seems like `DogView` can be replaced with a Unit-Like Struct (e.g., `struct PlaceHolderStruct;`) when using the above approach? But this results in a dead code warning from the compiler. I would have liked to link to a place with additional information, but I could not find any additional information in the docs. Maybe I missed it? If not, I would suggest removing it? Perhaps the [reference/router](https://dioxuslabs.com/learn/0.6/reference/router) page would be a good place to add this information back in? 
    - [Since the last merge request](https://github.com/DioxusLabs/docsite/pull/354), NavBar appears at this point in the tutorial for the first time. I have included some changes that introduce NavBar at this point.