### PR TITLE
Add `wasm32-unknown-unknown` target on setup

### DIFF
--- a/docs-src/0.6/src/getting_started/index.md
+++ b/docs-src/0.6/src/getting_started/index.md
@@ -23,7 +23,14 @@ You can follow the [installation instructions](https://rust-analyzer.github.io/m
 
 ## Install Rust
 
-Head over to [https://rust-lang.org](http://rust-lang.org) and install the Rust compiler.
+Head over to [https://rust-lang.org](http://rust-lang.org) and install the Rust compiler (preferably using `rustup`).
+
+Once installed, make sure you add the `stable` toolchain and the `wasm32-unknown-unknown` target for web development:
+
+```shell
+rustup toolchain install stable
+rustup target add wasm32-unknown-unknown
+```
 
 We strongly recommend going through the [official Rust book](https://doc.rust-lang.org/book/ch01-00-getting-started.html) _completely_. However, we hope that a Dioxus app can serve as a great first Rust project.
 

--- a/docs-src/0.6/src/guide/tooling.md
+++ b/docs-src/0.6/src/guide/tooling.md
@@ -10,7 +10,7 @@ We covered the setup instructions in [Getting Started](../getting_started/index.
 
 - Rust is installed
 - You have a code editor installed
-- The wasm32-unknown-unknown Rust toolchain is installed
+- The wasm32-unknown-unknown target is installed
 - The `dioxus-cli` is installed and up-to-date
 - System-specific dependencies are installed
 


### PR DESCRIPTION
The [Tooling > Checklist](https://dioxuslabs.com/learn/0.6/guide/tooling#checklist) section mentions ensuring the installation of the `wasm32-unknown-unknown` "Rust toolchain".

1. The [Getting Started](https://dioxuslabs.com/learn/0.6/getting_started/) page does not indicate how to set it up.
2. It is a compilation target, not a toolchain.