### PR TITLE
Fix dog image style in tutorial

### DIFF
--- a/docs-src/0.6/src/guide/assets.md
+++ b/docs-src/0.6/src/guide/assets.md
@@ -138,7 +138,7 @@ html, body {
     justify-content: center;
 }
 
-#dogimg {
+#dogview img {
     display: block;
     max-width: 50%;
     max-height: 50%;


### PR DESCRIPTION
Styles for dog image were in the tutorial CSS but there were no elements with id `#dogimg`. Rather than updating the examples with the id I think it's better to change the selector to `#dogview img`.

Before:
<img src="https://github.com/user-attachments/assets/983661ca-2bf7-4a06-a518-d9304786fcad" width="200">

After:
<img src="https://github.com/user-attachments/assets/4c78190d-cf60-46f7-9d55-4c424a3283c4" width="200">