### PR TITLE
Bumped version to 0.6.1 in version-selector.

### DIFF
--- a/src/docs.rs
+++ b/src/docs.rs
@@ -203,7 +203,7 @@ impl AnyBookRoute for router_06::BookRoute {
         "0.6"
     }
     fn full_version() -> &'static str {
-        "0.6.0"
+        "0.6.1"
     }
     fn index() -> Self {
         Self::Index {}


### PR DESCRIPTION
0.6.1 has been out for 2 weeks, docs version-selector on website still says 0.6.0.