### PR TITLE
docs: fix typo UpperCammelCase to UpperCamelCase

### DIFF
--- a/docs-src/0.3/en/describing_ui/components.md
+++ b/docs-src/0.3/en/describing_ui/components.md
@@ -2,13 +2,13 @@
 
 Just like you wouldn't want to write a complex program in a single, long, `main` function, you shouldn't build a complex UI in a single `App` function. Instead, you should break down the functionality of an app in logical parts called components.
 
-A component is a Rust function, named in UpperCammelCase, that takes a `Scope` parameter and returns an `Element` describing the UI it wants to render. In fact, our `App` function is a component!
+A component is a Rust function, named in UpperCamelCase, that takes a `Scope` parameter and returns an `Element` describing the UI it wants to render. In fact, our `App` function is a component!
 
 ```rust
 {{#include src/doc_examples/untested_03/hello_world_desktop.rs:component}}
 ```
 
-> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCammelCase component names
+> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCamelCase component names
 
 A Component is responsible for some rendering task – typically, rendering an isolated part of the user interface. For example, you could have an `About` component that renders a short description of Dioxus Labs:
 

--- a/docs-src/0.3/pt-br/describing_ui/components.md
+++ b/docs-src/0.3/pt-br/describing_ui/components.md
@@ -2,7 +2,7 @@
 
 Assim como você não gostaria de escrever um programa complexo em uma única e longa função `main`, você não deve construir uma interface complexa em uma única função `App`. Em vez disso, seria melhor dividir a funcionalidade de um aplicativo em partes lógicas chamadas componentes.
 
-Um componente é uma função Rust, nomeada em _UpperCammelCase_, que recebe um parâmetro `Scope` e retorna um `Element` descrevendo a interface do usuário que deseja renderizar. Na verdade, nossa função `App` é um componente!
+Um componente é uma função Rust, nomeada em _UpperCamelCase_, que recebe um parâmetro `Scope` e retorna um `Element` descrevendo a interface do usuário que deseja renderizar. Na verdade, nossa função `App` é um componente!
 
 ```rust
 {{#include src/doc_examples/untested_03/hello_world_desktop.rs:component}}

--- a/docs-src/0.4/en/reference/components.md
+++ b/docs-src/0.4/en/reference/components.md
@@ -2,13 +2,13 @@
 
 Just like you wouldn't want to write a complex program in a single, long, `main` function, you shouldn't build a complex UI in a single `App` function. Instead, you should break down the functionality of an app in logical parts called components.
 
-A component is a Rust function, named in UpperCammelCase, that takes a `Scope` parameter and returns an `Element` describing the UI it wants to render. In fact, our `App` function is a component!
+A component is a Rust function, named in UpperCamelCase, that takes a `Scope` parameter and returns an `Element` describing the UI it wants to render. In fact, our `App` function is a component!
 
 ```rust, no_run
 {{#include src/doc_examples/untested_04/hello_world_desktop.rs:component}}
 ```
 
-> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCammelCase component names
+> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCamelCase component names
 
 A Component is responsible for some rendering task – typically, rendering an isolated part of the user interface. For example, you could have an `About` component that renders a short description of Dioxus Labs:
 

--- a/docs-src/0.5/src/reference/components.md
+++ b/docs-src/0.5/src/reference/components.md
@@ -2,13 +2,13 @@
 
 Just like you wouldn't want to write a complex program in a single, long, `main` function, you shouldn't build a complex UI in a single `App` function. Instead, you should break down the functionality of an app in logical parts called components.
 
-A component is a Rust function, named in UpperCammelCase, that either takes no parameters or a properties struct and returns an `Element` describing the UI it wants to render.
+A component is a Rust function, named in UpperCamelCase, that either takes no parameters or a properties struct and returns an `Element` describing the UI it wants to render.
 
 ```rust, no_run
 {{#include src/doc_examples/hello_world_desktop.rs:component}}
 ```
 
-> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCammelCase component names
+> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCamelCase component names
 
 A Component is responsible for some rendering task – typically, rendering an isolated part of the user interface. For example, you could have an `About` component that renders a short description of Dioxus Labs:
 

--- a/docs-src/0.6/src/reference/components.md
+++ b/docs-src/0.6/src/reference/components.md
@@ -2,13 +2,13 @@
 
 Just like you wouldn't want to write a complex program in a single, long, `main` function, you shouldn't build a complex UI in a single `App` function. Instead, you should break down the functionality of an app in logical parts called components.
 
-A component is a Rust function, named in UpperCammelCase, that either takes no parameters or a properties struct and returns an `Element` describing the UI it wants to render.
+A component is a Rust function, named in UpperCamelCase, that either takes no parameters or a properties struct and returns an `Element` describing the UI it wants to render.
 
 ```rust, no_run
 {{#include src/doc_examples/hello_world_desktop.rs:component}}
 ```
 
-> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCammelCase component names
+> You'll probably want to add `#![allow(non_snake_case)]` to the top of your crate to avoid warnings about UpperCamelCase component names
 
 A Component is responsible for some rendering task – typically, rendering an isolated part of the user interface. For example, you could have an `About` component that renders a short description of Dioxus Labs:
 

--- a/src/docs/router_03.rs
+++ b/src/docs/router_03.rs
@@ -2909,7 +2909,7 @@ pub fn DescribingUiComponents() -> dioxus::prelude::Element {
             " function. Instead, you should break down the functionality of an app in logical parts called components."
         }
         p {
-            "A component is a Rust function, named in UpperCammelCase, that takes a  "
+            "A component is a Rust function, named in UpperCamelCase, that takes a  "
             code { "Scope" }
             " parameter and returns an  "
             code { "Element" }
@@ -2925,7 +2925,7 @@ pub fn DescribingUiComponents() -> dioxus::prelude::Element {
             p {
                 "You'll probably want to add  "
                 code { "#![allow(non_snake_case)]" }
-                " to the top of your crate to avoid warnings about UpperCammelCase component names"
+                " to the top of your crate to avoid warnings about UpperCamelCase component names"
             }
         }
         p {

--- a/src/docs/router_04.rs
+++ b/src/docs/router_04.rs
@@ -6555,7 +6555,7 @@ pub fn ReferenceComponents() -> dioxus::prelude::Element {
             " function. Instead, you should break down the functionality of an app in logical parts called components."
         }
         p {
-            "A component is a Rust function, named in UpperCammelCase, that takes a  "
+            "A component is a Rust function, named in UpperCamelCase, that takes a  "
             code { "Scope" }
             " parameter and returns an  "
             code { "Element" }
@@ -6571,7 +6571,7 @@ pub fn ReferenceComponents() -> dioxus::prelude::Element {
             p {
                 "You'll probably want to add  "
                 code { "#![allow(non_snake_case)]" }
-                " to the top of your crate to avoid warnings about UpperCammelCase component names"
+                " to the top of your crate to avoid warnings about UpperCamelCase component names"
             }
         }
         p {

--- a/src/docs/router_05.rs
+++ b/src/docs/router_05.rs
@@ -5337,7 +5337,7 @@ pub fn ReferenceComponents() -> dioxus::prelude::Element {
             " function. Instead, you should break down the functionality of an app in logical parts called components."
         }
         p {
-            "A component is a Rust function, named in UpperCammelCase, that either takes no parameters or a properties struct and returns an  "
+            "A component is a Rust function, named in UpperCamelCase, that either takes no parameters or a properties struct and returns an  "
             code { "Element" }
             " describing the UI it wants to render."
         }
@@ -5349,7 +5349,7 @@ pub fn ReferenceComponents() -> dioxus::prelude::Element {
             p {
                 "You'll probably want to add  "
                 code { "#![allow(non_snake_case)]" }
-                " to the top of your crate to avoid warnings about UpperCammelCase component names"
+                " to the top of your crate to avoid warnings about UpperCamelCase component names"
             }
         }
         p {

--- a/src/docs/router_06.rs
+++ b/src/docs/router_06.rs
@@ -13342,7 +13342,7 @@ pub fn ReferenceComponents() -> dioxus::prelude::Element {
             " function. Instead, you should break down the functionality of an app in logical parts called components."
         }
         p {
-            "A component is a Rust function, named in UpperCammelCase, that either takes no parameters or a properties struct and returns an  "
+            "A component is a Rust function, named in UpperCamelCase, that either takes no parameters or a properties struct and returns an  "
             code { "Element" }
             " describing the UI it wants to render."
         }
@@ -13354,7 +13354,7 @@ pub fn ReferenceComponents() -> dioxus::prelude::Element {
             p {
                 "You'll probably want to add  "
                 code { "#![allow(non_snake_case)]" }
-                " to the top of your crate to avoid warnings about UpperCammelCase component names"
+                " to the top of your crate to avoid warnings about UpperCamelCase component names"
             }
         }
         p {


### PR DESCRIPTION
Minor typo batch replaced.