### PR TITLE
Update configure.md

### DIFF
--- a/docs-src/0.6/src/CLI/configure.md
+++ b/docs-src/0.6/src/CLI/configure.md
@@ -327,9 +327,6 @@ This includes all fields, mandatory or not.
 # App name
 name = "project_name"
 
-# The Dioxus platform to default to
-default_platform = "web"
-
 # `build` & `serve` output path
 out_dir = "dist"
 


### PR DESCRIPTION
It appears the `default_platform` config in the local Dioxus config [was removed](https://github.com/DioxusLabs/dioxus/pull/3108). It was still in the example. So this cleans that up.