### PR TITLE
Stop google results from old docs

### DIFF
--- a/src/docs/router_06.rs
+++ b/src/docs/router_06.rs
@@ -10312,7 +10312,7 @@ pub fn GuideNextSteps(section: GuideNextStepsSection) -> dioxus::prelude::Elemen
         }
         p {
             "Challenge yourself by adding new features to "
-            em { "HotDop" }
+            em { "HotDog" }
             "."
         }
         ul {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,10 @@ fn HeaderFooter() -> Element {
 
 fn Head() -> Element {
     use document::{Link, Meta, Script, Stylesheet, Title};
+    
+    // Tell google to not index old documentation
+    let current_doc_route = use_route::<Route>();
+    let don_t_index = current_doc_route.is_docs() && !current_doc_route.is_latest_docs(); 
 
     rsx! {
         Title { "Dioxus | Fullstack crossplatform app framework for Rust" }
@@ -133,6 +137,9 @@ fn Head() -> Element {
             r#async: true,
             src: asset!("/assets/gtag.js"),
             r#type: "text/javascript",
+        }
+        if don_t_index {
+            Meta { name: "robots", content: "noindex" }
         }
     }
 }


### PR DESCRIPTION
Unfortunately, the nudge in #344 doesn't look like it is effecting search results very much. This PR removes all old docs from search engines