### PR TITLE
Fix search index generation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Install CLI
         run: cargo binstall dioxus-cli -y --force --version 0.6
       - name: Build
-        run: DIOXUS_LOG=dx=trace dx build --platform web --fullstack --features fullstack --release --ssg
+        run: DIOXUS_LOG=dx=trace dx build --platform web --fullstack --features fullstack,production --release --ssg
+      - name: Generate search index
+        run: target/dx/dioxus_docs_site/release/web/server --generate-search-index
       - name: Copy output
         run: cp -r target/dx/dioxus_docs_site/release/web/public docs
       - name: Add gh pages 404

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,3 +143,4 @@ doc_test = [
     "server",
     "dioxus/fullstack"
 ]
+production = []

--- a/src/components/nav.rs
+++ b/src/components/nav.rs
@@ -204,10 +204,10 @@ fn SearchModal() -> Element {
     let mut search_text = use_signal(String::new);
 
     let search_index = use_resource(|| async move {
-        #[cfg(debug_assertions)]
+        #[cfg(not(feature = "production"))]
         let url = "http://localhost:8080/assets/dioxus_search/index_searchable.bin";
 
-        #[cfg(not(debug_assertions))]
+        #[cfg(feature = "production")]
         let url = "https://dioxuslabs.com/assets/dioxus_search/index_searchable.bin";
 
         let data = reqwest::get(url).await.ok()?.bytes().await.ok()?;

--- a/src/components/search.rs
+++ b/src/components/search.rs
@@ -1,26 +1,17 @@
-use dioxus::prelude::*;
-
-/// we use a component at the end of the router to generate the search index once the rest
-/// of the pages have been ssr-ed during SSG.
-#[component]
-pub fn Search() -> Element {
+pub fn generate_search_index() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         use crate::{static_dir, Route};
-        use once_cell::sync::Lazy;
+        use std::sync::atomic::{AtomicBool, Ordering};
 
-        static _INDEX: Lazy<bool> = Lazy::new(|| {
+        static INDEX_FRESH: AtomicBool = AtomicBool::new(false);
+        let index_fresh = INDEX_FRESH.swap(true, Ordering::Relaxed);
+        if !index_fresh {
             std::env::set_var("CARGO_MANIFEST_DIR", static_dir().join("assets"));
             dioxus_search::SearchIndex::<Route>::create(
                 "searchable",
                 dioxus_search::BaseDirectoryMapping::new(static_dir()),
             );
-
-            true
-        });
-
-        assert!(*_INDEX == true);
+        }
     }
-
-    rsx! {}
 }

--- a/src/components/search.rs
+++ b/src/components/search.rs
@@ -4,14 +4,10 @@ pub fn generate_search_index() {
         use crate::{static_dir, Route};
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        static INDEX_FRESH: AtomicBool = AtomicBool::new(false);
-        let index_fresh = INDEX_FRESH.swap(true, Ordering::Relaxed);
-        if !index_fresh {
-            std::env::set_var("CARGO_MANIFEST_DIR", static_dir().join("assets"));
-            dioxus_search::SearchIndex::<Route>::create(
-                "searchable",
-                dioxus_search::BaseDirectoryMapping::new(static_dir()),
-            );
-        }
+        std::env::set_var("CARGO_MANIFEST_DIR", static_dir().join("assets"));
+        dioxus_search::SearchIndex::<Route>::create(
+            "searchable",
+            dioxus_search::BaseDirectoryMapping::new(static_dir()),
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,13 @@ pub mod snippets;
 pub use components::*;
 
 fn main() {
+    // If we are just building the search index, we don't need to launch the app
+    #[cfg(feature = "server")]
+    if std::env::args().any(|arg| arg == "--generate-search-index") {
+        search::generate_search_index();
+        return;
+    }
+    
     create_sitemap();
 
     dioxus::LaunchBuilder::new()
@@ -186,11 +193,6 @@ pub enum Route {
             #[end_nest]
         #[end_layout]
     #[end_nest]
-
-    // once all the routes above have been generated, we build the search index
-    // a bit of a hack, sorry
-    #[route("/search")]
-    Search {},
 
     #[redirect("/docs/:..segments", |segments: Vec<String>| {
         let joined = segments.join("/");


### PR DESCRIPTION
This should only be merged after https://github.com/DioxusLabs/dioxus-search/pull/4 is merged. The CLI tries to render routes in parallel, so generating the search index in a component is a race condition. If the search index is rendered before the rest of the pages, then the index will have a incorrect url structure. This PR moves search index generation to a separate step after SSG

It also adds a production flag so the search index generation can be tested locally

Fixes #405 