### PR TITLE
Add cargo bin to path in deploy documentation

### DIFF
--- a/docs-src/0.6/src/guide/deploy.md
+++ b/docs-src/0.6/src/guide/deploy.md
@@ -85,6 +85,7 @@ COPY . .
 # Install `dx`
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 RUN cargo binstall dioxus-cli --root /.cargo -y --force
+ENV PATH="/.cargo/bin:$PATH"
 
 # Create the final bundle folder. Bundle always executes in release mode with optimizations enabled
 RUN dx bundle --platform web


### PR DESCRIPTION
Resolves the `/bin/sh: 1: dx: not found` error during the docker build 