### PR TITLE
Fix: Playground Run Button Background

### DIFF
--- a/packages/playground/playground/assets/dxp.css
+++ b/packages/playground/playground/assets/dxp.css
@@ -540,6 +540,7 @@
 
   #dxp-run-btn {
     color: var(--dxp-text-dark);
+    background-color: var(--dxp-bg-dark-lighter);
   }
 
   #dxp-run-btn>svg {


### PR DESCRIPTION
It didn't have a dark-theme background media query.