### PR TITLE
Update bundle.md to fix icon error

### DIFF
--- a/docs-src/0.6/src/guide/bundle.md
+++ b/docs-src/0.6/src/guide/bundle.md
@@ -196,7 +196,7 @@ name = "docsite"
 [bundle]
 identifier = "com.dioxuslabs"
 publisher = "DioxusLabs"
-icon = "assets/icon.png"
+icon = ["assets/icon.png"]
 ```
 
 For a full list of options, see the [reference page on the `bundle` section](../cookbook/bundling.md).


### PR DESCRIPTION
The icon argument requires a vec of strings, just a string causes the bundle to fail