### PR TITLE
Fix wording in introduction about `rsx!` macro

### DIFF
--- a/docs-src/0.6/src/index.md
+++ b/docs-src/0.6/src/index.md
@@ -48,7 +48,7 @@ Our vision for Dioxus is a framework that is fast, flexible, and has a minimal l
 
 ## Syntax and Ecosystem
 
-The Dioxus syntax is similar to React's JSX markup, borrowing React's component and hooks approach. All components are Rust functions that take `Properties`, define state with hooks, and return an `Element`. We only support markup in with the `rsx! {}` markup; this ensures your app is automatically optimized and has stellar devtools support like advanced hot-reloading.
+The Dioxus syntax is similar to React's JSX markup, borrowing React's component and hooks approach. All components are Rust functions that take `Properties`, define state with hooks, and return an `Element`. We only support markup within the `rsx! {}` macro; this ensures your app is automatically optimized and has stellar devtools support like advanced hot-reloading.
 
 ```rust
 #[component]


### PR DESCRIPTION
Please note that I don't actually know if what I wrote, that `rsx!` is the only way to create markup, is true. I only deduced that from the broken wording that was there before.