### PR TITLE
Fix very long words in search index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5010,7 +5010,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5596,8 +5596,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stork-lib"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91da154bfff411d476e715c79d5810241751802dd6e4b08990e1112c0b8f8976"
+source = "git+https://github.com/dioxuslabs/stork#86f4e8d8ffdf285b44bf94dfa7ff1d2c3d9f5ad8"
 dependencies = [
  "bytes",
  "frontmatter",
@@ -5825,7 +5824,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6719,7 +6718,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ exclude = ["packages/playground/server/template"]
 
 [workspace.dependencies]
 dioxus_docs_router = { path = "packages/docs-router" }
+stork-lib = { git = "https://github.com/dioxuslabs/stork", default-features = false }
 
 # mdbook
 mdbook-gen = { path = "packages/include_mdbook/packages/mdbook-gen" }
@@ -93,6 +94,45 @@ debug = 0
 
 [profile.android-dev]
 inherits = "dev"
+
+[profile.wasm-release]
+inherits = "release"
+
+[profile.server-release]
+inherits = "release"
+
+[profile.ios-dev]
+inherits = "dev"
+
+[profile.ios-release]
+inherits = "release"
+
+[profile.android-release]
+inherits = "release"
+
+[profile.windows-dev]
+inherits = "dev"
+
+[profile.windows-release]
+inherits = "release"
+
+[profile.macos-dev]
+inherits = "dev"
+
+[profile.macos-release]
+inherits = "release"
+
+[profile.linux-dev]
+inherits = "dev"
+
+[profile.linux-release]
+inherits = "release"
+
+[profile.liveview-dev]
+inherits = "dev"
+
+[profile.liveview-release]
+inherits = "release"
 
 [profile.release.build-override]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,45 +95,6 @@ debug = 0
 [profile.android-dev]
 inherits = "dev"
 
-[profile.wasm-release]
-inherits = "release"
-
-[profile.server-release]
-inherits = "release"
-
-[profile.ios-dev]
-inherits = "dev"
-
-[profile.ios-release]
-inherits = "release"
-
-[profile.android-release]
-inherits = "release"
-
-[profile.windows-dev]
-inherits = "dev"
-
-[profile.windows-release]
-inherits = "release"
-
-[profile.macos-dev]
-inherits = "dev"
-
-[profile.macos-release]
-inherits = "release"
-
-[profile.linux-dev]
-inherits = "dev"
-
-[profile.linux-release]
-inherits = "release"
-
-[profile.liveview-dev]
-inherits = "dev"
-
-[profile.liveview-release]
-inherits = "release"
-
 [profile.release.build-override]
 opt-level = 3
 codegen-units = 1

--- a/packages/docs-router/Cargo.toml
+++ b/packages/docs-router/Cargo.toml
@@ -46,7 +46,7 @@ gloo-timers = { version = "0.3.0", features = ["futures"] }
 js-sys = "0.3.64"
 form_urlencoded = "1.2.0"
 automod = "1.0.13"
-stork-lib = { version = "1.6.0", features = [
+stork-lib = { workspace = true, features = [
     "build-v3",
 ], default-features = false }
 

--- a/packages/docsite/Cargo.toml
+++ b/packages/docsite/Cargo.toml
@@ -48,7 +48,7 @@ futures-util = "0.3"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 js-sys = "0.3.64"
 automod = "1.0.13"
-stork-lib = { version = "1.6.0", features = [
+stork-lib = { workspace = true, features = [
     "build-v3",
 ], default-features = false }
 

--- a/packages/docsite/src/components/search.rs
+++ b/packages/docsite/src/components/search.rs
@@ -2,12 +2,26 @@ pub fn generate_search_index() {
     #[cfg(not(target_arch = "wasm32"))]
     {
         use crate::{static_dir, Route};
-        use std::sync::atomic::{AtomicBool, Ordering};
 
         std::env::set_var("CARGO_MANIFEST_DIR", static_dir().join("assets"));
-        dioxus_search::SearchIndex::<Route>::create(
-            "searchable",
-            dioxus_search::BaseDirectoryMapping::new(static_dir()),
-        );
+        let version_filter: [(&str, fn(&Route) -> bool); 4] = [
+            ("0_3", |route| matches!(route, Route::Docs03 { .. })),
+            ("0_4", |route| matches!(route, Route::Docs04 { .. })),
+            ("0_5", |route| matches!(route, Route::Docs05 { .. })),
+            ("0_6", |route| matches!(route, Route::Docs06 { .. })),
+        ];
+        for (version, filter) in version_filter {
+            dioxus_search::SearchIndex::<Route>::create(
+                format!("searchable_{version}"),
+                dioxus_search::BaseDirectoryMapping::new(static_dir()).map(|route| {
+                    filter(&route).then(|| {
+                        let route = route.to_string();
+                        let (route, _) = route.split_once('#').unwrap_or((&route, ""));
+                        let (route, _) = route.split_once('?').unwrap_or((&route, ""));
+                        std::path::PathBuf::from(route).join("index.html")
+                    })
+                }),
+            );
+        }
     }
 }

--- a/packages/search/search-shared/Cargo.toml
+++ b/packages/search/search-shared/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 toml = "0.8.19"
-stork-lib = { version = "1.6.0", features = ["build-v3"], default-features = false }
+stork-lib = { workspace = true, features = ["build-v3"], default-features = false }
 bytes = { version = "1.3.0", features = ["serde"] }
 slab = "0.4.8"
 dioxus-router = { version = "0.6.0" }

--- a/packages/search/search-shared/src/lib.rs
+++ b/packages/search/search-shared/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     fmt::{Debug, Display},
-    num::ParseIntError,
     path::PathBuf,
     str::FromStr,
 };

--- a/packages/search/search/Cargo.toml
+++ b/packages/search/search/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 toml = "0.7.4"
-stork-lib = { version = "1.6.0", features = ["build-v3"], default-features = false }
+stork-lib = { workspace = true, features = ["build-v3"], default-features = false }
 bytes = { version = "1.3.0", features = ["serde"] }
 slab = "0.4.8"
 dioxus-router = { version = "0.6.0" }


### PR DESCRIPTION
CI is currently failing because it runs out of memory. There is a bug in the stork indexer that makes it index results inside of scripts. This PR just switches to our fork of stork which filters out very long words to fix the issue

It also split up the search indexes per doc version to make them quicker to create and search through

Reference CI build with this PR: https://github.com/ealmloff/docsite/actions/runs/13292609974/job/37116831300