### PR TITLE
Fix section links on right navigation bar, which don't work when punctuated

### DIFF
--- a/packages/include_mdbook/packages/mdbook-shared/src/query.rs
+++ b/packages/include_mdbook/packages/mdbook-shared/src/query.rs
@@ -88,6 +88,19 @@ pub struct Section {
     pub id: String,
 }
 
+pub fn text_to_anchor(text: String) -> String {
+    //  Taken from method on private mdbook-gen::rsx::Section.
+    text.trim()
+        .to_lowercase()
+        .chars()
+        .filter_map(|char| match char {
+            '-' | 'a'..='z' | '0'..='9' => Some(char),
+            ' ' | '_' => Some('-'),
+            _ => None,
+        })
+        .collect()
+}
+
 impl MdBook<PathBuf> {
     pub fn new(mdbook_root: PathBuf) -> anyhow::Result<Self> {
         let buf = get_summary_path(&mdbook_root)
@@ -179,16 +192,10 @@ impl MdBook<PathBuf> {
             }
             Event::Text(text) => {
                 if let Some(current_level) = &mut last_heading {
-                    let anchor = text
-                        .clone()
-                        .into_string()
-                        .trim()
-                        .to_lowercase()
-                        .replace(' ', "-");
                     sections.push(Section {
                         level: *current_level as usize,
                         title: text.to_string(),
-                        id: anchor,
+                        id: text_to_anchor(text.to_string()),
                     });
 
                     last_heading = None;


### PR DESCRIPTION
Ids are rendered differently when parsed from markdown and rendered, from when they are inserted into the vector that populates the right navigation bar. As a result, links on the right navigation bar do not work if they contain punctuation, or any characters besides `[0-9a-zA-Z\-]`. 

For example. on the page [https://dioxuslabs.com/learn/0.6/](https://dioxuslabs.com/learn/0.6), clicking the link [Who's funding dioxus?](https://dioxuslabs.com/learn/0.6/#who's-funding-dioxus?) appends `#who's-funding-dioxus?` to the url, but that anchor is rendered with the `id="whos-funding-dioxus"`. 

So I just took the code that renders id for the section based on the title, and replicated it for the code that inserts the sections into the vector that populates the menu. Unfortunately these two `Section` structs are different, and the one that is used in rendering the page is private.