### PR TITLE
increase contrast of search bar

### DIFF
--- a/packages/docsite/src/components/awesome.rs
+++ b/packages/docsite/src/components/awesome.rs
@@ -149,7 +149,7 @@ pub(crate) fn AwesomeInner() -> Element {
                             class: "mx-2 rounded-lg lg:w-2/5 lg:mx-auto",
                             background_color: "#24292f",
                             input {
-                                class: "w-full text-center p-4 rounded-lg text-gray-300 bg-gray-100",
+                                class: "w-full text-center p-4 rounded-lg text-gray-500 bg-gray-100",
                                 placeholder: "Looking for something specific?",
                                 value: "{search}",
                                 oninput: move |evt| search.set(evt.value()),


### PR DESCRIPTION
Currently, IMO, the text is a little hard to read:
![grafik](https://github.com/user-attachments/assets/dd81fd6a-9047-4745-ad9a-12787f633ffe)

Increasing the contrast would help :-)