### PR TITLE
Fix: Hero Button Spacing

### DIFF
--- a/packages/docsite/src/components/homepage/hero.rs
+++ b/packages/docsite/src/components/homepage/hero.rs
@@ -31,7 +31,7 @@ pub(crate) fn Hero() -> Element {
                             Link {
                                 to: "https://www.youtube.com/watch?v=WgAjWPKRVlQ",
                                 new_tab: true,
-                                class: "bg-[#EDEDED] dark:bg-ghdarkmetal  text-black dark:text-white border border-[#a4a9ac7d]  m-0 p-2 px-4 rounded md:hover:-translate-y-1 transition-transform duration-300 w-full md:w-auto gap-2 flex flex-row items-center justify-center",
+                                class: "bg-[#EDEDED] dark:bg-ghdarkmetal text-black dark:text-white border border-[#a4a9ac7d] m-0 ml-2 p-2 px-4 rounded md:hover:-translate-y-1 transition-transform duration-300 w-full md:w-auto gap-2 flex flex-row items-center justify-center",
                                 "Take a tour"
                                 span {
                                     svg {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1eed1a78-17c4-4747-b4b2-4e767c713314)

After:
![image](https://github.com/user-attachments/assets/2db39193-4ae5-4488-92ef-b109723677c7)
