### PR TITLE
Update tailwind.md

### DIFF
--- a/docs-src/0.6/src/cookbook/tailwind.md
+++ b/docs-src/0.6/src/cookbook/tailwind.md
@@ -44,6 +44,10 @@ module.exports = {
 6. Create a `input.css` file in the root of your project with the following content:
 
 ```css
+/* only for tailwind v4.0 */
+@import tailwindcss;
+
+/* for tailwind under v4.0  */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
I was going through Dioxus tutorial last night, and decided to use `tailwind` for styling. I am on Tailwind version 4, and noticed a good amount of utility classes weren't in `/assets/tailwind-15fc2b73cc87e636.css`.

For Tailwind version 4, you'll have to `@import tailwindcss` in [your input.css file](https://tailwindcss.com/docs/installation/tailwind-cli)