### PR TITLE
the as_ref() is not needed anymore and is bringing errors

### DIFF
--- a/packages/docs-router/src/doc_examples/asynchronous.rs
+++ b/packages/docs-router/src/doc_examples/asynchronous.rs
@@ -580,7 +580,7 @@ mod use_server_future {
         // If the future was still pending, it would have returned suspended with the `?` above
         // we can unwrap the None case here to get the inner result
         let response_read = response.read();
-        let response = response_read.as_ref().unwrap();
+        let response = response_read.unwrap();
 
         // Then you can just handle the happy path with the resolved future
         rsx! {


### PR DESCRIPTION
if you call as_ref the match expr will return an error of

`GenerationalRef<Ref<'_, Result<YOURTYPE, ServerFnError<YOURERROR>>>>`

but if you call unwrap direcly it works as intended