### PR TITLE
Fix LeftNav styling

### DIFF
--- a/packages/docsite/assets/tailwind.css
+++ b/packages/docsite/assets/tailwind.css
@@ -2006,11 +2006,26 @@
       height: 88vh;
     }
   }
-  .md\:min-h-\[520px\] {
-    @media (width >= 48rem) {
-      min-height: 520px;
+    .md\:h-\[calc\(100vh_-_calc\(var\(--spacing\)_\*_28\)\)\] {
+      @media (width >= 48rem) {
+        height: calc(100vh - calc(var(--spacing) * 28));
+      }
     }
-  }
+    .md\:h-full {
+      @media (width >= 48rem) {
+        height: 100%;
+      }
+    }
+    .md\:min-h-\[520px\] {
+      @media (width >= 48rem) {
+        min-height: 520px;
+      }
+    }
+    .md\:flex-col {
+      @media (width >= 48rem) {
+        flex-direction: column;
+      }
+    }
   .md\:w-60 {
     @media (width >= 48rem) {
       width: calc(var(--spacing) * 60);

--- a/packages/docsite/src/components/learn.rs
+++ b/packages/docsite/src/components/learn.rs
@@ -63,12 +63,12 @@ fn LeftNav<R: AnyBookRoute>() -> Element {
     rsx! {
         div {
             class: if SHOW_SIDEBAR() { "w-full md:w-auto" } else { "hidden" },
-            class: "h-full md:block top-28 sticky",
-            div { class: "lg:block mb-2 md:text-[14px] leading-5 text-gray-700  dark:text-gray-400 space-y-2 px-4 md:px-2 py-2 md:py-0",
+            class: "h-full md:block top-28 sticky md:h-[calc(100vh_-_calc(var(--spacing)_*_28))]",
+            div { class: "md:flex md:flex-col md:h-full mb-2 md:text-[14px] leading-5 text-gray-700 dark:text-gray-400 space-y-2 px-4 md:px-2 py-2 md:py-0",
                 VersionSwitch {}
                 nav { class: "
                 styled-scrollbar
-                pl-2 pb-2 z-20 text-base sm:block top-28 md:h-[88vh]
+                pl-2 pb-2 z-20 text-base sm:block top-28
                 md:w-60 lg:text-[14px] content-start text-gray-600 dark:text-gray-400 overflow-y-scroll pr-2 space-y-1",
                     for chapter in chapters.into_iter().flatten().filter(|chapter| chapter.maybe_link().is_some()) {
                         SidebarSection { chapter }


### PR DESCRIPTION
Fix the styling of LeftNav to ensure the bottom of the nav is never cut off on desktop clients. I hope my tailwindcli didnt fuck up the css file, the site looks the same from my testing, but it removed a lot of variables and classes, that's why the diff is so large.

Current site, the Translate HTML link is not visible despite being scrolled to the bottom of the element:
![Screenshot_20250325_004352](https://github.com/user-attachments/assets/7778b9f0-3ecf-445c-8f32-d0a30105517a)

My fix, the Translate HTML link is clearly visible:
![Screenshot_20250325_004557](https://github.com/user-attachments/assets/cd089d0b-2282-40d3-a0d7-ff9ef5acae00)
