### PR TITLE
Fix ToC link parsing and truncation

### DIFF
--- a/packages/include_mdbook/packages/mdbook-gen-example/src/router.rs
+++ b/packages/include_mdbook/packages/mdbook-gen-example/src/router.rs
@@ -88,7 +88,7 @@ pub static LAZY_BOOK: use_mdbook::Lazy<use_mdbook::mdbook_shared::MdBook<BookRou
                 sections: vec![
                     ::use_mdbook::mdbook_shared::Section {
                         title: "Roadmap & Feature-set".to_string(),
-                        id: "roadmap-&-feature-set".to_string(),
+                        id: "roadmap--feature-set".to_string(),
                         level: 1usize,
                     },
                     ::use_mdbook::mdbook_shared::Section {
@@ -123,7 +123,7 @@ pub static LAZY_BOOK: use_mdbook::Lazy<use_mdbook::mdbook_shared::MdBook<BookRou
                     },
                     ::use_mdbook::mdbook_shared::Section {
                         title: "Bundling (CLI)".to_string(),
-                        id: "bundling-(cli)".to_string(),
+                        id: "bundling-cli".to_string(),
                         level: 3usize,
                     },
                     ::use_mdbook::mdbook_shared::Section {


### PR DESCRIPTION
This pull request fixes the ToC link parsing. This prevents ToC links pointing to headers incorrectly as described in #466 it also fixes headers being truncated for example on https://dioxuslabs.com/blog/release-060 this fixes all ToC links as far as I can tell.