### PR TITLE
Update tooling.md wasm32-unknown-unknown is a target, choose false for tailwind css

### DIFF
--- a/docs-src/0.6/src/guide/new_app.md
+++ b/docs-src/0.6/src/guide/new_app.md
@@ -21,7 +21,7 @@ We're going to use the bare-bones template for *HotDog*. Our app won't be too co
 
 - Select "false" when asked if you want to create a fullstack website.
 - Select "false" for the router, though we *will* eventually add the router to the app.
-- Select no for TailwindCSS. If you want to use Tailwind, make sure to read the [TailwindCSS guide](../cookbook/tailwind.md).
+- Select "false" for TailwindCSS. If you want to use Tailwind, make sure to read the [TailwindCSS guide](../cookbook/tailwind.md).
 - Select "Web" as the default platform.
 
 > 📣 You don't need `dx new` to create new Dioxus apps! Dioxus apps are Rust projects and can also be built with tools like cargo.

--- a/docs-src/0.6/src/guide/tooling.md
+++ b/docs-src/0.6/src/guide/tooling.md
@@ -10,7 +10,7 @@ We covered the setup instructions in [Getting Started](../getting_started/index.
 
 - Rust is installed
 - You have a code editor installed
-- The wasm32-unknown-unknown Rust toolchain is installed
+- The wasm32-unknown-unknown Rust target is installed
 - The `dioxus-cli` is installed and up-to-date
 - System-specific dependencies are installed
 


### PR DESCRIPTION
To install wasm32-unknown-unknown, you need to use the command `rustup target add wasm32-unknown-unknown`. Rustup also has a concept of toolchains. Changing `toolchain` to `target` will likely help people find the right command as they may otherwise be confused if they try to run `rustup toolchain install wasm32-unknown-unknown`.

Hope this helps.