### PR TITLE
Fix github pages publishing documentation

### DIFF
--- a/docs-src/0.6/src/cookbook/publishing.md
+++ b/docs-src/0.6/src/cookbook/publishing.md
@@ -9,8 +9,6 @@ Edit your `Dioxus.toml` to point your `out_dir` to the `docs` folder and the `ba
 ```toml
 [application]
 # ...
-out_dir = "docs"
-
 [web.app]
 base_path = "your_repo"
 ```
@@ -18,11 +16,18 @@ base_path = "your_repo"
 Then build your app and publish it to Github:
 
 - Make sure GitHub Pages is set up for your repo to publish any static files in the docs directory
-- Build your app with:
+- Build your app into the `docs` directory with:
 ```sh
-dx build --release
+dx bundle --out-dir docs
 ```
-- Make a copy of your `docs/index.html` file and rename the copy to `docs/404.html` so that your app will work with client-side routing
+- Move the static content from `docs/public` to `docs`
+```sh
+mv docs/public/* docs
+```
+- Make a copy of your `docs/index.html` file and rename the copy to `docs/404.html` so that your app will work with client-side routing:
+```sh
+cp docs/index.html docs/404.html
+```
 - Add and commit with git
 - Push to GitHub
 


### PR DESCRIPTION
The github pages documentation points to the old out dir setting. This PR fixes that issue. I verified the new process works with this repo: https://github.com/ealmloff/test-gh-pages

Fixes https://github.com/DioxusLabs/dioxus/issues/3834