### PR TITLE
Add android platform tools to path in android setup

### DIFF
--- a/docs-src/0.6/src/guides/mobile/index.md
+++ b/docs-src/0.6/src/guides/mobile/index.md
@@ -49,7 +49,7 @@ Mac:
 export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
 export ANDROID_HOME="$HOME/Library/Android/sdk"
 export NDK_HOME="$ANDROID_HOME/ndk/25.2.9519653"
-export PATH="$PATH:$ANDROID_HOME/emulator"
+export PATH="$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools"
 ```
 
 Windows:


### PR DESCRIPTION
Kept getting this error when trying to serve my app to my android phone over usb, saw some other people on the discord had the same issue
```
failed to forward port 8080: No such file or directory (os error 2)
```
Found it in the [source code](https://github.com/DioxusLabs/dioxus/blob/6733e43cc2256a66d2ada771a1c02524041e36cb/packages/cli/src/serve/handle.rs#L731) that it was because adb wasn't found. This gets installed to ANDROID_HOME/platform-tools/adb but that wasn't on my path, so just documenting that that needs to be added on