### PR TITLE
fix: replace manage_state guide links with rules_of_hooks

### DIFF
--- a/docs-src/0.6/src/guide/state.md
+++ b/docs-src/0.6/src/guide/state.md
@@ -36,7 +36,7 @@ When called in a component, the `use_hook` function will return a `.clone()` of 
 {{#include src/doc_examples/guide_state.rs:use_hook}}
 ```
 
-Dioxus hooks are very similar to React's hooks and need to follow some [simple rules](../guides/managing_state.md#the-rules-of-hooks) to function properly.
+Dioxus hooks are very similar to React's hooks and need to follow some [simple rules](../guides/rules_of_hooks.md) to function properly.
 
 ## Signals and use_signal
 

--- a/docs-src/0.6/src/guides/index.md
+++ b/docs-src/0.6/src/guides/index.md
@@ -4,7 +4,7 @@ These guides contains more detailed explanations for some concepts covered in th
 
 ## State
 
-- [State management](managing_state.md) (signals-based reactivity)
+- [Rules of hooks](rules_of_hooks.md) (signals-based reactivity)
 
 ## Assets
 


### PR DESCRIPTION
The `manage_state` guide was previously renamed to `rules_of_hooks`, this updates some references to the old file, which will hopefully unblock builds - it at least fixed `dx serve` locally. Happy to make more changes if needed, thanks!