### PR TITLE
Use ReactiveContext in custom hook example

### DIFF
--- a/docs-src/0.5/src/cookbook/state/custom_hooks/index.md
+++ b/docs-src/0.5/src/cookbook/state/custom_hooks/index.md
@@ -35,7 +35,7 @@ Inside the initialization closure, you will typically make calls to other `cx` m
 Here is a simplified implementation of the `use_signal` hook:
 
 ```rust
-{{#include src/doc_examples/hooks_custom_logic.rs:use_signal}}
+{{#include src/doc_examples/untested_05/hooks_custom_logic.rs:use_signal}}
 ```
 
 - The `use_context` hook calls [`consume_context`](https://docs.rs/dioxus/latest/dioxus/prelude/fn.consume_context.html) (which would be expensive to call on every render) to get some context from the component
@@ -43,5 +43,5 @@ Here is a simplified implementation of the `use_signal` hook:
 Here is an implementation of the `use_context` and `use_context_provider` hooks:
 
 ```rust
-{{#include src/doc_examples/hooks_custom_logic.rs:use_context}}
+{{#include src/doc_examples/untested_05/hooks_custom_logic.rs:use_context}}
 ```

--- a/docs-src/0.5/zh/cookbook/state/custom_hooks/index.md
+++ b/docs-src/0.5/zh/cookbook/state/custom_hooks/index.md
@@ -35,7 +35,7 @@ Inside the initialization closure, you will typically make calls to other `cx` m
 Here is a simplified implementation of the `use_signal` hook:
 
 \```rust
-{{#include src/doc_examples/hooks_custom_logic.rs:use_signal}}
+{{#include src/doc_examples/untested_05/hooks_custom_logic.rs:use_signal}}
 \```
 
 - The `use_context` hook calls [`consume_context`](https://docs.rs/dioxus/latest/dioxus/prelude/fn.consume_context.html) (which would be expensive to call on every render) to get some context from the component
@@ -43,5 +43,5 @@ Here is a simplified implementation of the `use_signal` hook:
 Here is an implementation of the `use_context` and `use_context_provider` hooks:
 
 \```rust
-{{#include src/doc_examples/hooks_custom_logic.rs:use_context}}
+{{#include src/doc_examples/untested_05/hooks_custom_logic.rs:use_context}}
 \```

--- a/docs-src/0.6/src/cookbook/state/custom_hooks/index.md
+++ b/docs-src/0.6/src/cookbook/state/custom_hooks/index.md
@@ -30,7 +30,7 @@ You can use [`use_hook`](https://docs.rs/dioxus/latest/dioxus/prelude/fn.use_hoo
 
 Inside the initialization closure, you will typically make calls to other `cx` methods. For example:
 
-- The `use_signal` hook tracks state in the hook value, and uses [`schedule_update`](https://docs.rs/dioxus/latest/dioxus/prelude/fn.schedule_update.html) to make Dioxus re-render the component whenever it changes.
+- The `use_signal` hook tracks state in the hook value, and uses [`ReactiveContext`](https://docs.rs/dioxus/latest/dioxus/prelude/struct.ReactiveContext.html) to make Dioxus re-render any component that has observed it whenever the signal's value changes.
 
 Here is a simplified implementation of the `use_signal` hook:
 


### PR DESCRIPTION
Update custom hook example to use ReactiveContext as proposed in https://github.com/DioxusLabs/dioxus/issues/4114.

I haven't worked on these docs before, so I'm not sure what the process is, but from looking at existing docs I guessed this is the correct set of changes.