### PR TITLE
Changed: second use_signal() hook to a different use_effect() in the example - for more given examples

### DIFF
--- a/docs-src/0.5/src/reference/hooks.md
+++ b/docs-src/0.5/src/reference/hooks.md
@@ -71,7 +71,7 @@ This is only possible because the two hooks are always called in the same order,
 3. The same hooks must be called (except in the case of early returns, as explained later in the [Error Handling chapter](../cookbook/error_handling.md)).
 4. In the same order.
 5. Hook names should start with `use_` so you don't accidentally confuse them with regular
-   functions (`use_signal()`, `use_signal()`, `use_resource()`, etc...).
+   functions (`use_signal()`, `use_effect()`, `use_resource()`, etc...).
 
 These rules mean that there are certain things you can't do with hooks:
 

--- a/docs-src/0.5/zh/reference/hooks.md
+++ b/docs-src/0.5/zh/reference/hooks.md
@@ -71,7 +71,7 @@ This is only possible because the two hooks are always called in the same order,
 3. The same hooks must be called (except in the case of early returns, as explained later in the [Error Handling chapter](../../cookbook/error_handling.md)).
 4. In the same order.
 5. Hook names should start with `use_` so you don't accidentally confuse them with regular
-   functions (`use_signal()`, `use_signal()`, `use_resource()`, etc...).
+   functions (`use_signal()`, `use_effect()`, `use_resource()`, etc...).
 
 These rules mean that there are certain things you can't do with hooks:
 

--- a/docs-src/0.6/src/reference/hooks.md
+++ b/docs-src/0.6/src/reference/hooks.md
@@ -71,7 +71,7 @@ This is only possible because the two hooks are always called in the same order,
 3. The same hooks must be called (except in the case of early returns, as explained later in the [Error Handling chapter](../essentials/error_handling/index.md)).
 4. In the same order.
 5. Hook names should start with `use_` so you don't accidentally confuse them with regular
-   functions (`use_signal()`, `use_signal()`, `use_resource()`, etc...).
+   functions (`use_signal()`, `use_effect()`, `use_resource()`, etc...).
 
 These rules mean that there are certain things you can't do with hooks:
 


### PR DESCRIPTION
When I was reading the documentation, I was a bit confused why in the listing examples of hooks, you mentioned `use_signals()` twice - I think  you meant to use another hook, just a typo, so I fixed it