### PR TITLE
Properties <-> Props

### DIFF
--- a/docs-src/0.6/src/guide/component.md
+++ b/docs-src/0.6/src/guide/component.md
@@ -12,7 +12,7 @@ In Dioxus, apps are comprised of individual functions called *Components* that t
 
 ## Component Properties
 
-All components take an object that outlines which parameters the component can accept. All `Props` structs in Dioxus need to derive the `Properties` trait which requires both `Clone` and `PartialEq`:
+All components take an object that outlines which parameters the component can accept. All property structs in Dioxus need to derive the `Props` trait which requires both `Clone` and `PartialEq`:
 
 ```rust
 {{#include src/doc_examples/guide_component.rs:dog_app_component_props}}


### PR DESCRIPTION
According to the example in the [rendered version of the document](https://dioxuslabs.com/learn/0.6/guide/component/) the trait is called `Props`, not `Properties`, which the guide seemed to hint at. Not sure if I'm just misreading this, but I hope this change improves the clarity of the sentence.