### PR TITLE
Import logger before calling tracing::info in code sample

### DIFF
--- a/packages/docs-router/src/doc_examples/guide_component.rs
+++ b/packages/docs-router/src/doc_examples/guide_component.rs
@@ -30,6 +30,9 @@ mod dog_app_component_props_clone {
     use dioxus::prelude::*;
 
     // ANCHOR: dog_app_component_props_clone
+    // ...
+    use dioxus::logger::*;
+
     #[component]
     fn DogApp(breed: String) -> Element {
         tracing::info!("Rendered with breed: {breed}");


### PR DESCRIPTION
I'm going through the documentation to get acquainted with dioxus.
I was confused as of where `tracing::info` was coming from in the guide, as there was no mention of the logger earlier. I think displaying an import of it before it's used can be useful.