### PR TITLE
Bundle is .ipa for iOS

### DIFF
--- a/docs-src/0.6/src/guide/bundle.md
+++ b/docs-src/0.6/src/guide/bundle.md
@@ -150,7 +150,7 @@ When bundling installable apps, there are many distribution formats to choose fr
 - macOS: `.app`, `.dmg`
 - Linux: `.appimage`, `.rpm`, `.deb`
 - Windows: `.msi`, `.exe`
-- iOS: `.app`
+- iOS: `.ipa`
 - Android: `.apk`
 
 You can specify package types like so:


### PR DESCRIPTION
If I'm not mistaking, the bundle extension for iOS is `.ipa` and not `.app`