### PR TITLE
Build llms.txt before copying the docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,12 +34,10 @@ jobs:
         run: cargo binstall dioxus-cli -y --force --version 0.7.0-alpha.3
       - name: Build
         run: cd packages/docsite && dx build --verbose --trace --platform web --fullstack true --features fullstack,production --release --ssg
-      - name: Copy output
-        run: cp -r target/dx/dioxus_docs_site/release/web/public docs
       - name: Generate search index
         run: target/dx/dioxus_docs_site/release/web/dioxus_docs_site --generate-search-index
-      - name: Copy search index
-        run: cp -rf target/dx/dioxus_docs_site/release/web/public/assets/dioxus_search docs/assets/dioxus_search
+      - name: Copy output
+        run: cp -r target/dx/dioxus_docs_site/release/web/public docs
       - name: Add gh pages 404
         run: cp docs/index.html docs/404.html
       - name: Deploy 🚀

--- a/packages/docsite/src/components/llms.rs
+++ b/packages/docsite/src/components/llms.rs
@@ -48,7 +48,7 @@ pub fn generate_llms_txt() {
             writeln!(file, "<SYSTEM>This is the developer documentation for Dioxus from {route}.</SYSTEM>\n{content}")?;
             file.write_all(content.as_bytes())?;
 
-            // Move up the tree of routes and add the content to each paren route's llms-full.txt
+            // Move up the tree of routes and add the content to each parent route's llms-full.txt
             let mut current_doc_route = doc_route;
             while let Some(doc_route) = current_doc_route.parent() {
                 // Only write the latest docs to the root llms-full.txt


### PR DESCRIPTION
Currently we copy the docs into the folder, build the search index and then copy only the search index from the changed docs. This doesn't include the llms.txt for each page. This PR swaps the order so we generate the search index and then copy the llms.txt and the search index along with the rest of the docs