### PR TITLE
Changed out of order streaming docs to use .with_cfg instead of .with_context

### DIFF
--- a/packages/docs-router/src/doc_examples/untested_06/asynchronous.rs
+++ b/packages/docs-router/src/doc_examples/untested_06/asynchronous.rs
@@ -639,7 +639,7 @@ mod use_server_future_streaming {
     // ANCHOR: use_server_future_streaming
     fn main() {
         dioxus::LaunchBuilder::new()
-            .with_context(server_only! {
+            .with_cfg(server_only! {
                 // Enable out of order streaming during SSR
                 dioxus::fullstack::ServeConfig::builder().enable_out_of_order_streaming()
             })


### PR DESCRIPTION
Fixed #535 