### PR TITLE
Fix Tailwind CLI example of the input.css file

### DIFF
--- a/docs-src/0.7/src/guides/utilities/tailwind.md
+++ b/docs-src/0.7/src/guides/utilities/tailwind.md
@@ -18,8 +18,7 @@ cargo install dioxus-cli
 4. Create a `input.css` file in the root of your project with the following content:
 
 ```css
-@import "tailwindcss";
-@source "./src/**/*.{rs,html,css}";
+@import "tailwindcss" source("./src/**/*.{rs,html,css}");
 ```
 
 5. Create a link to the `tailwind.css` file using manganis somewhere in your rust code:


### PR DESCRIPTION
Running the Tailwind CLI as outlined in the current file can lead to extreme memory usage of npx, as every subdirectory of the project dir is watched for changes.

According to https://tailwindcss.com/docs/detecting-classes-in-source-files#setting-your-base-path the proposed sample only includes files from the `src/` subdirectory of the project, mitigating the issue.