### PR TITLE
Fix typo in 0.7 docs

### DIFF
--- a/docs-src/0.7/src/essentials/ui/conditional.md
+++ b/docs-src/0.7/src/essentials/ui/conditional.md
@@ -184,7 +184,7 @@ rsx! {
 }
 ```
 
-Inline `if` statements deviate from Rust in one way: they still evaluate to an `Element` even without an `else` branch. If RSX doesn't find an `else` branch on your `if` statement, it automatically returns a placeholder element instead.a
+Inline `if` statements deviate from Rust in one way: they still evaluate to an `Element` even without an `else` branch. If RSX doesn't find an `else` branch on your `if` statement, it automatically returns a placeholder element instead.
 
 ```rust
 rsx! {


### PR DESCRIPTION
Removes accidental "a". Noticed while going through them