### PR TITLE
fix: match the docs with video example

### DIFF
--- a/packages/docs-router/src/doc_examples/guide_data_fetching.rs
+++ b/packages/docs-router/src/doc_examples/guide_data_fetching.rs
@@ -14,7 +14,7 @@ mod dog_view_reqwest {
     fn DogView() -> Element {
         let mut img_src = use_signal(|| "".to_string());
 
-        let fetch_new = move |_| async move {
+        let save = move |_| async move {
             let response = reqwest::get("https://dog.ceo/api/breeds/image/random")
                 .await
                 .unwrap()
@@ -33,7 +33,7 @@ mod dog_view_reqwest {
             }
             div { id: "buttons",
                 // ..
-                button { onclick: fetch_new, id: "save", "save!" }
+                button { onclick: save, id: "save", "save!" }
             }
         }
     }


### PR DESCRIPTION
Code in the video does not match the code in markdown

<img width="1114" height="889" alt="image" src="https://github.com/user-attachments/assets/f77d229b-b0dc-49a3-b2a7-7e955fdfbb76" />
