### PR TITLE
guides/tips/optimizing - remove recommendation to strip

### DIFF
--- a/docs-src/0.7/src/guides/tips/optimizing.md
+++ b/docs-src/0.7/src/guides/tips/optimizing.md
@@ -63,7 +63,6 @@ debug = false
 lto = true
 codegen-units = 1
 panic = "abort"
-strip = true
 incremental = false
 ```
 


### PR DESCRIPTION
Now in 0.7, stripping is problematic and specifically recommended against.  This removes the `strip = true` from the WASM optimization recommendations accordingly.

Fixes [#4880](https://github.com/DioxusLabs/dioxus/issues/4880)