### PR TITLE
Fix tutorial list examples

### DIFF
--- a/packages/docs-router/src/doc_examples/guide_rsx.rs
+++ b/packages/docs-router/src/doc_examples/guide_rsx.rs
@@ -47,7 +47,7 @@ fn RsxExpression() -> Element {
 
         // And iterators
         ul {
-            {(0..5).map(|i| rsx! { "{i}" })}
+            {(0..5).map(|i| rsx! { li { "{i}" } })}
         }
     }
     // ANCHOR_END: rsx_expression
@@ -63,7 +63,7 @@ fn RsxLoop() -> Element {
 
         ul {
             for item in 0..5 {
-                "{item}"
+                li { "{item}" }
             }
         }
     }


### PR DESCRIPTION
Hi!

I am currently trying Dioxus with the tutorial. On [Creating UI with RSX](https://dioxuslabs.com/learn/0.7/tutorial/rsx) there are examples with for-loops. I assume the author of the tutorial would to create a list of numbers so the `ul` element should contain `li` elements.

About my patch: I am not sure about the formatting rules so I do not know if 
```rust
{(0..5).map(|i| rsx! { li { "{i}" } })}
```
is best practice.