### PR TITLE
Removing misleading information from hero page

### DIFF
--- a/packages/docsite/src/components/homepage/hero.rs
+++ b/packages/docsite/src/components/homepage/hero.rs
@@ -76,14 +76,6 @@ pub(crate) fn Hero() -> Element {
                         "Trusted by top companies"
                     }
                     div { class: "flex flex-row flex-wrap lg:justify-start justify-center invert dark:invert-0  gap-8  min-h-0",
-                        img {
-                            class: "h-6",
-                            src: asset!("/assets/static/airbuslogo.svg"),
-                        }
-                        img {
-                            class: "h-6 ",
-                            src: asset!("/assets/static/ESA_logo.svg"),
-                        }
                         // img {
                         //     class: "h-6 ",
                         //     src: asset!("/assets/static/xailogo.svg"),


### PR DESCRIPTION
I noticed that the Dioxus hero page currently displays the ESA and Airbus logos, but there is no direct mention or confirmation of their involvement or usage of Dioxus.

There is no mention of ESA or Airbus on the Dioxus Blog; however, from [this Y-Combinator post](https://www.ycombinator.com/launches/JBK-dioxus-labs-web-desktop-and-mobile-apps-with-one-codebase), the inclusion of the ESA and Airbus logos on the hero page stems from them supposedly using [Skytrace](https://skytrace.space/). However, I can't find any statements coming directly from ESA or Airbus about their usage of the service.

Looking at the [Skytrace GitHub repository](https://github.com/purton-tech/skytrace), the project seems to be an abandoned personal project, which makes me believe that it is not actually used by real-world space companies.

Please inform me if I am wrong, but I believe that more transparency on the Dioxus blog could help with this.