### PR TITLE
fix: Fix incorrect var name in component properties example

### DIFF
--- a/docs-src/0.7/src/essentials/ui/components.md
+++ b/docs-src/0.7/src/essentials/ui/components.md
@@ -62,8 +62,8 @@ struct CardProps {
 #[component]
 fn Card(props: CardProps) -> Element {
   rsx! {
-      h1 { "{card.title}" }
-      span { "{card.content}" }
+      h1 { "{props.title}" }
+      span { "{props.content}" }
     }
 }
 ```


### PR DESCRIPTION
Between the transition from v0.6 to v0.7 the variable name was changed to `card` when it presumably should be `props`.

Current v0.7 docs: https://dioxuslabs.com/learn/0.7/essentials/ui/components#component-properties

Equivalent v0.6 docs: https://dioxuslabs.com/learn/0.6/reference/component_props#the-component-macro

v6 source: https://github.com/DioxusLabs/docsite/blob/2a25a70edc956f096723942018b1ddf50e5480ca/docs-src/0.6/src/reference/component_props.md?plain=1#L94-L103

