### PR TITLE
Getting started: update install.sh to run with bash not sh

### DIFF
--- a/docs-src/0.7/src/getting_started/index.md
+++ b/docs-src/0.7/src/getting_started/index.md
@@ -25,7 +25,7 @@ We've put a lot of care into making Dioxus syntax familiar and easy to understan
 Dioxus ships with its own build tool that leverages `cargo` to provide integrated hot-reloading, bundling, and development servers for web and mobile. You can download the prebuilt binary with the following command:
 
 ```sh
-curl -sSL http://dioxus.dev/install.sh | sh
+curl -sSL http://dioxus.dev/install.sh | bash
 ```
 
 You can also download with `cargo-binstall`:


### PR DESCRIPTION
The script uses `[[ ]]` syntax for conditionals, which is a [bash feature](https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html#index-_005b_005b) not supported in vanilla sh.

Tested on Ubuntu 25.10. The current install script errors with:

```
./install.sh: 16: [[: not found
./install.sh: 50: [[: not found
./install.sh: 69: [[: not found
#=O#-    #       #                                                                                                                                                                                                                    curl: (22) The requested URL returned error: 404
```

On this system, /bin/sh is symlinked to dash.
On some systems where /bin/sh is symlinked to bash, the current script would work fine.

This change will make the script work on more systems. A future change could revise the script to be POSIX shell compliant if there's a big need for this to run on systems that don't have bash.

Complementary PR to change the shebang in install.sh to say /bin/bash for clarity: https://github.com/DioxusLabs/dioxus/pull/4965