### PR TITLE
fix: Incorrect module path used for logger in init example

### DIFF
--- a/docs-src/0.7/src/guides/utilities/logging.md
+++ b/docs-src/0.7/src/guides/utilities/logging.md
@@ -29,7 +29,7 @@ use tracing::Level;
 
 fn main() {
     // Init logger
-    dioxus_logger::init(Level::INFO).expect("failed to init logger");
+    dioxus::logger::init(Level::INFO).expect("failed to init logger");
 
     // Dioxus launch code
     dioxus::launch(|| rsx! {})


### PR DESCRIPTION
The logger init example seems to refer to a different crate when the init method can be accessed as `dioxus::logger::init`.