### PR TITLE
Update dependencies in getting_started index.md

### DIFF
--- a/docs-src/0.7/src/getting_started/index.md
+++ b/docs-src/0.7/src/getting_started/index.md
@@ -84,7 +84,8 @@ sudo apt install libwebkit2gtk-4.1-dev \
   libxdo-dev \
   libssl-dev \
   libayatana-appindicator3-dev \
-  librsvg2-dev
+  librsvg2-dev \
+  lld
 ```
 
 For arch:


### PR DESCRIPTION
Added 'lld' to the list of dependencies in Ubuntu for installation.

Maybe it needs to be added to Arch as well.