### PR TITLE
Fix hydration of suspended resource in guide

### DIFF
--- a/docs-src/0.7/src/tutorial/routing.md
+++ b/docs-src/0.7/src/tutorial/routing.md
@@ -171,7 +171,7 @@ Finally, we can build our favorites page. Let's add a new `list_dogs` server fun
 {{#include ../docs-router/src/doc_examples/guide_router.rs:list_dogs}}
 ```
 
-Now, we can fill in our component. We're going to use the same `use_resource` hook from earlier. Resolving the request from the server might take some time, so we'll use the `.suspend()?` method on `Resource` to wait for the request to finish before mapping the contents to a list.
+Now, we can fill in our component. Resolving the request from the server might take some time, so we'll use the `use_server_future(...)?` to wait for the request to finish before mapping the contents to a list. `use_server_future` is very similar to `use_resource`, but it waits for the future to finish before continuing rendering and integrates with dioxus fullstack to serialize that data from the server to the client.
 
 ```rust
 {{#include ../docs-router/src/doc_examples/guide_router.rs:favorites_list_dogs}}

--- a/packages/docs-router/src/doc_examples/guide_router.rs
+++ b/packages/docs-router/src/doc_examples/guide_router.rs
@@ -197,13 +197,13 @@ mod list_dogs {
         #[component]
         pub fn Favorites() -> Element {
             // Create a pending resource that resolves to the list of dogs from the backend
-            // Wait for the favorites list to resolve with `.suspend()`
-            let mut favorites = use_resource(super::backend::list_dogs).suspend()?;
+            // Wait for the favorites list to resolve with `?`
+            let mut favorites = use_server_future(super::backend::list_dogs)?;
 
             rsx! {
                 div { id: "favorites",
                     div { id: "favorites-container",
-                        for (id, url) in favorites().unwrap() {
+                        for (id, url) in favorites().unwrap().unwrap() {
                             // Render a div for each photo using the dog's ID as the list key
                             div {
                                 key: "{id}",


### PR DESCRIPTION
The guide uses `use_resource().suspend()?` after adding a backend with dioxus fullstack instead of `use_server_future` which causes hydration errors. This PR moves to use_server_future instead to fix the issue

Fixes https://github.com/DioxusLabs/dioxus/issues/5053