### PR TITLE
Pre-written documentation for `onunmounted` lifecycle event

### DIFF
--- a/docs-src/0.7/src/essentials/advanced/breaking_out.md
+++ b/docs-src/0.7/src/essentials/advanced/breaking_out.md
@@ -61,6 +61,47 @@ DemoFrame {
 }
 ```
 
+## Cleaning up when elements are removed with `onunmounted`
+
+> **Note:** This feature is coming soon in a future Dioxus release. See [PR #5113](https://github.com/DioxusLabs/dioxus/pull/5113) for progress.
+
+The `onunmounted` event is the counterpart to `onmounted`. It fires after an element is removed from the DOM, allowing you to clean up any resources associated with that element.
+
+This is particularly useful for:
+- Animation engines that need to deregister elements
+- State tracking systems that need to clean up when elements disappear
+- Releasing resources tied to specific DOM elements
+
+Unlike `use_drop`, which fires when an entire component unmounts, `onunmounted` fires at the element level. This means you can track when individual elements within a component are removed, even if the parent component remains mounted.
+
+```rust, no_run
+fn ToggleElement() -> Element {
+    let mut show = use_signal(|| true);
+    let mut status = use_signal(|| String::from("Element is mounted"));
+
+    rsx! {
+        div {
+            button {
+                onclick: move |_| show.toggle(),
+                if show() { "Hide element" } else { "Show element" }
+            }
+            if show() {
+                div {
+                    style: "width: 100px; height: 100px; background-color: #3b82f6;",
+                    onmounted: move |_| {
+                        status.set(String::from("Element was mounted"));
+                    },
+                    onunmounted: move |_| {
+                        status.set(String::from("Element was unmounted"));
+                    },
+                }
+            }
+            div { "{status}" }
+        }
+    }
+}
+```
+
 ## Down casting web sys events
 
 Dioxus provides platform agnostic wrappers over each event type. These wrappers are often nicer to interact with than the raw event types, but they can be more limited. If you are targeting web, you can downcast the event with the `as_web_event` method to get the underlying web-sys event:

--- a/docs-src/0.7/src/essentials/advanced/lifecycle.md
+++ b/docs-src/0.7/src/essentials/advanced/lifecycle.md
@@ -62,3 +62,24 @@ DemoFrame {
     component_lifecycle::DropDemo {}
 }
 ```
+
+## Cleaning Up Elements with `onunmounted`
+
+> **Note:** This feature is coming soon in a future Dioxus release. See [PR #5113](https://github.com/DioxusLabs/dioxus/pull/5113) for progress.
+
+While `use_drop` fires when an entire component is dropped, sometimes you need to know when a specific element within a component is removed from the DOM. For this, you can use the `onunmounted` event.
+
+This is particularly useful when you have conditional elements or lists where individual items can be added or removed while the parent component remains mounted:
+
+```rust, no_run
+div {
+    onmounted: move |_| {
+        // Register the element with some external system
+    },
+    onunmounted: move |_| {
+        // Clean up when the element is removed
+    },
+}
+```
+
+See the [Breaking Out of Dioxus](./breaking_out.md#cleaning-up-when-elements-are-removed-with-onunmounted) chapter for a complete example.

--- a/packages/docs-router/src/doc_examples/breaking_out.rs
+++ b/packages/docs-router/src/doc_examples/breaking_out.rs
@@ -2,6 +2,8 @@ use dioxus::prelude::*;
 pub use downcast::Downcast;
 pub use eval::Eval;
 pub use onmounted_::OnMounted;
+// TODO: Uncomment when onunmounted lands (PR #5113)
+// pub use onunmounted_::OnUnmounted;
 pub use use_effect::Canvas;
 pub use web_sys::WebSys;
 
@@ -143,3 +145,38 @@ mod onmounted_ {
     }
     // ANCHOR_END: onmounted
 }
+
+// TODO: Uncomment when onunmounted lands (PR #5113)
+// mod onunmounted_ {
+//     use super::*;
+//
+//     // ANCHOR: onunmounted
+//     pub fn OnUnmounted() -> Element {
+//         let mut show = use_signal(|| true);
+//         let mut status = use_signal(|| String::from("Element is mounted"));
+//
+//         rsx! {
+//             div {
+//                 button {
+//                     onclick: move |_| show.toggle(),
+//                     if show() { "Hide element" } else { "Show element" }
+//                 }
+//                 if show() {
+//                     div {
+//                         style: "width: 100px; height: 100px; background-color: #3b82f6; margin: 10px 0;",
+//                         // The onmounted event fires when the element is added to the DOM
+//                         onmounted: move |_| {
+//                             status.set(String::from("Element was mounted"));
+//                         },
+//                         // The onunmounted event fires when the element is removed from the DOM
+//                         onunmounted: move |_| {
+//                             status.set(String::from("Element was unmounted"));
+//                         },
+//                     }
+//                 }
+//                 div { "{status}" }
+//             }
+//         }
+//     }
+//     // ANCHOR_END: onunmounted
+// }


### PR DESCRIPTION
## Summary

Documentation for the `onunmounted` lifecycle event. Code is commented out until the feature lands.

## After [dioxus#5113](https://github.com/DioxusLabs/dioxus/pull/5113) is merged

1. `packages/docs-router/src/doc_examples/breaking_out.rs`:
    
    - Uncomment line 6 and lines 150-182
2. `docs-src/0.7/src/essentials/advanced/breaking_out.md`:
    
    - Remove the "coming soon" blockquote (line 66)
    - Replace lines 77-103 with:
        
        ````
        ```rust, no_run
        {{#include ../docs-router/src/doc_examples/breaking_out.rs:onunmounted}}
        ````
        
        ```inject-dioxus
        DemoFrame {
            breaking_out::OnUnmounted {}
        }
        ```
        
3. `docs-src/0.7/src/essentials/advanced/lifecycle.md`:
    
    - Remove the "coming soon" blockquote (line 68)