### PR TITLE
essentials/basics/context: remove possibly unintended variable shadowing from example

### DIFF
--- a/docs-src/0.7/src/essentials/basics/context.md
+++ b/docs-src/0.7/src/essentials/basics/context.md
@@ -93,7 +93,7 @@ use_context_provider(|| Subtitle("Hello world!".to_string()));
 To consume the context, we pass in the appropriate struct type:
 ```rust
 let title = use_context::<Title>();
-let title = use_context::<Subtitle>();
+let subtitle = use_context::<Subtitle>();
 ```
 
 In practice, you don't need to wrap *every* field of your state in a newtype, usually just one struct to encapsulate a set of data is enough.


### PR DESCRIPTION
just a quick drive by PR as I noticed this *very* minor issue while reading the docs (it doesn't matter but annoys me slightly)

lmk if small PRs like this are more work than help