### PR TITLE
Fix end-to-end testing repository links

### DIFF
--- a/docs-src/0.7/src/guides/testing/web.md
+++ b/docs-src/0.7/src/guides/testing/web.md
@@ -41,6 +41,6 @@ webServer: [
 ],
 ```
 
-- [Web example](https://github.com/DioxusLabs/dioxus/tree/main/playwright-tests/web)
-- [Liveview example](https://github.com/DioxusLabs/dioxus/tree/main/playwright-tests/liveview)
-- [Fullstack example](https://github.com/DioxusLabs/dioxus/tree/main/playwright-tests/fullstack)
+- [Web example](https://github.com/DioxusLabs/dioxus/tree/main/packages/playwright-tests/web)
+- [Liveview example](https://github.com/DioxusLabs/dioxus/tree/main/packages/playwright-tests/liveview)
+- [Fullstack example](https://github.com/DioxusLabs/dioxus/tree/main/packages/playwright-tests/fullstack)


### PR DESCRIPTION
The current links 404, the files are nested under `packages/`.