### PR TITLE
docs: fix typos in documentation and error messages

### DIFF
--- a/docs-src/0.3/en/best_practices/error_handling.md
+++ b/docs-src/0.3/en/best_practices/error_handling.md
@@ -68,7 +68,7 @@ fn Commandline(cx: Scope) -> Element {
 
     cx.render(match *error {
         Some(error) => rsx!(
-            h1 { "An error occured" }
+            h1 { "An error occurred" }
         )
         None => rsx!(
             input {
@@ -88,7 +88,7 @@ fn Commandline(cx: Scope) -> Element {
     let error = use_state(cx, || None);
 
     if let Some(error) = **error {
-        return cx.render(rsx!{ "An error occured" });
+        return cx.render(rsx!{ "An error occurred" });
     }
 
     cx.render(rsx!{

--- a/docs-src/0.3/pt-br/best_practices/error_handling.md
+++ b/docs-src/0.3/pt-br/best_practices/error_handling.md
@@ -64,7 +64,7 @@ fn Commandline(cx: Scope) -> Element {
 
     cx.render(match *error {
         Some(error) => rsx!(
-            h1 { "An error occured" }
+            h1 { "An error occurred" }
         )
         None => rsx!(
             input {
@@ -84,7 +84,7 @@ fn Commandline(cx: Scope) -> Element {
     let error = use_state(cx, || None);
 
     if let Some(error) = **error {
-        return cx.render(rsx!{ "An error occured" });
+        return cx.render(rsx!{ "An error occurred" });
     }
 
     cx.render(rsx!{

--- a/docs-src/0.4/src/cookbook/custom_renderer.md
+++ b/docs-src/0.4/src/cookbook/custom_renderer.md
@@ -50,7 +50,7 @@ The Dioxus diffing mechanism operates as a [stack machine](https://en.wikipedia.
 
 ## Node storage
 
-Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as as a u64.
+Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as a u64.
 
 Whenever a `CreateElement` edit is generated during diffing, Dioxus increments its node counter and assigns that new element its current NodeCount. The RealDom is responsible for remembering this ID and pushing the correct node when id is used in a mutation. Dioxus reclaims the IDs of elements when removed. To stay in sync with Dioxus you can use a sparse Vec (Vec<Option<T>>) with possibly unoccupied items. You can use the ids as indexes into the Vec for elements, and grow the Vec when an id does not exist.
 

--- a/docs-src/0.5/src/cookbook/custom_renderer.md
+++ b/docs-src/0.5/src/cookbook/custom_renderer.md
@@ -50,7 +50,7 @@ The Dioxus diffing mechanism operates as a [stack machine](https://en.wikipedia.
 
 ## Node storage
 
-Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as as a u64.
+Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as a u64.
 
 Whenever a `CreateElement` edit is generated during diffing, Dioxus increments its node counter and assigns that new element its current NodeCount. The RealDom is responsible for remembering this ID and pushing the correct node when id is used in a mutation. Dioxus reclaims the IDs of elements when removed. To stay in sync with Dioxus you can use a sparse Vec (Vec<Option<T>>) with possibly unoccupied items. You can use the ids as indexes into the Vec for elements, and grow the Vec when an id does not exist.
 

--- a/docs-src/0.5/src/cookbook/integrations/logging.md
+++ b/docs-src/0.5/src/cookbook/integrations/logging.md
@@ -2,7 +2,7 @@
 Dioxus has a wide range of supported platforms, each with their own logging requirements. We'll discuss the different options available for your projects.
 
 #### The Tracing Crate
-The [Tracing](https://crates.io/crates/tracing) crate is the logging interface that the Dioxus library uses. It is not required to use the Tracing crate, but you will not recieve logs from the Dioxus library.
+The [Tracing](https://crates.io/crates/tracing) crate is the logging interface that the Dioxus library uses. It is not required to use the Tracing crate, but you will not receive logs from the Dioxus library.
 
 The Tracing crate provides a variety of simple `println`-like macros with varying levels of severity. 
 The available macros are as follows with the highest severity on the bottom:

--- a/docs-src/0.5/src/migration/index.md
+++ b/docs-src/0.5/src/migration/index.md
@@ -2,7 +2,7 @@
 
 This guide will outline the API changes between the `0.4` and `0.5` releases.
 
-`0.5` has includes significant changes to hooks, props, and global state.
+`0.5` includes significant changes to hooks, props, and global state.
 
 ## Cheat Sheet
 

--- a/docs-src/0.5/src/reference/context.md
+++ b/docs-src/0.5/src/reference/context.md
@@ -64,7 +64,7 @@ As a result, any child component of `App` (direct or not), can access the `DarkM
 
 > `use_context` returns `Signal<DarkMode>` here, because the Signal was provided by the parent. If the context hadn't been provided `use_context` would have panicked.
 
-If you have a component where the context might or not be provided, you might want to use `try_consume_context`instead, so you can handle the `None` case. The drawback of this method is that it will not memoize the value between renders, so it won't be as as efficient as `use_context`, you could do it yourself with `use_hook` though.
+If you have a component where the context might or not be provided, you might want to use `try_consume_context`instead, so you can handle the `None` case. The drawback of this method is that it will not memoize the value between renders, so it won't be as efficient as `use_context`, you could do it yourself with `use_hook` though.
 
 For example, here's how we would implement the dark mode toggle, which both reads the context (to determine what color it should render) and writes to it (to toggle dark mode):
 

--- a/docs-src/0.5/zh/cookbook/custom_renderer.md
+++ b/docs-src/0.5/zh/cookbook/custom_renderer.md
@@ -50,7 +50,7 @@ The Dioxus diffing mechanism operates as a [stack machine](https://en.wikipedia.
 
 ## Node storage
 
-Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as as a u64.
+Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as a u64.
 
 Whenever a `CreateElement` edit is generated during diffing, Dioxus increments its node counter and assigns that new element its current NodeCount. The RealDom is responsible for remembering this ID and pushing the correct node when id is used in a mutation. Dioxus reclaims the IDs of elements when removed. To stay in sync with Dioxus you can use a sparse Vec (Vec<Option<T>>) with possibly unoccupied items. You can use the ids as indexes into the Vec for elements, and grow the Vec when an id does not exist.
 

--- a/docs-src/0.5/zh/cookbook/integrations/logging.md
+++ b/docs-src/0.5/zh/cookbook/integrations/logging.md
@@ -2,7 +2,7 @@
 Dioxus has a wide range of supported platforms, each with their own logging requirements. We'll discuss the different options available for your projects.
 
 #### The Tracing Crate
-The [Tracing](https://crates.io/crates/tracing) crate is the logging interface that the Dioxus library uses. It is not required to use the Tracing crate, but you will not recieve logs from the Dioxus library.
+The [Tracing](https://crates.io/crates/tracing) crate is the logging interface that the Dioxus library uses. It is not required to use the Tracing crate, but you will not receive logs from the Dioxus library.
 
 The Tracing crate provides a variety of simple `println`-like macros with varying levels of severity. 
 The available macros are as follows with the highest severity on the bottom:

--- a/docs-src/0.5/zh/migration/index.md
+++ b/docs-src/0.5/zh/migration/index.md
@@ -2,7 +2,7 @@
 
 This guide will outline the API changes between the `0.4` and `0.5` releases.
 
-`0.5` has includes significant changes to hooks, props, and global state.
+`0.5` includes significant changes to hooks, props, and global state.
 
 ## Cheat Sheet
 

--- a/docs-src/0.5/zh/reference/context.md
+++ b/docs-src/0.5/zh/reference/context.md
@@ -64,7 +64,7 @@ As a result, any child component of `App` (direct or not), can access the `DarkM
 
 > `use_context` returns `Signal<DarkMode>` here, because the Signal was provided by the parent. If the context hadn't been provided `use_context` would have panicked.
 
-If you have a component where the context might or not be provided, you might want to use `try_consume_context`instead, so you can handle the `None` case. The drawback of this method is that it will not memoize the value between renders, so it won't be as as efficient as `use_context`, you could do it yourself with `use_hook` though.
+If you have a component where the context might or not be provided, you might want to use `try_consume_context`instead, so you can handle the `None` case. The drawback of this method is that it will not memoize the value between renders, so it won't be as efficient as `use_context`, you could do it yourself with `use_hook` though.
 
 For example, here's how we would implement the dark mode toggle, which both reads the context (to determine what color it should render) and writes to it (to toggle dark mode):
 

--- a/docs-src/0.6/src/guide/tooling.md
+++ b/docs-src/0.6/src/guide/tooling.md
@@ -18,7 +18,7 @@ We covered the setup instructions in [Getting Started](../getting_started/index.
 
 Before proceeding, make sure you have the `dioxus-cli` installed and up-to-date.
 
-Verify the returned version matches this guide (eg 0.6) by running:
+Verify the returned version matches this guide (e.g., 0.6) by running:
 
 ```sh
 dx --version

--- a/docs-src/0.6/src/index.md
+++ b/docs-src/0.6/src/index.md
@@ -88,7 +88,7 @@ Dioxus has not reached a "1.0" release yet.
 
 We are currently on version 0.6, which has stabilized a huge number of APIs and drastically improved the developer experience. In version 0.5 we overhauled the state management system and in 0.6 we overhauled tooling.
 
-It's likely that the next few versions of Dioxus (0.7, 0.8) will bring breaking changes to your apps. Fortunately, these planned changes will only affect the syntax of specific APIs and not your apps at large. With every version update, we ship a rather comprehensive migration guide - eg [0.6](migration/index.md).
+It's likely that the next few versions of Dioxus (0.7, 0.8) will bring breaking changes to your apps. Fortunately, these planned changes will only affect the syntax of specific APIs and not your apps at large. With every version update, we ship a rather comprehensive migration guide, e.g., [0.6](migration/index.md).
 
 ## Examples, projects, tutorials, and more
 

--- a/docs-src/0.6/src/reference/context.md
+++ b/docs-src/0.6/src/reference/context.md
@@ -64,7 +64,7 @@ As a result, any child component of `App` (direct or not), can access the `DarkM
 
 > `use_context` returns `Signal<DarkMode>` here, because the Signal was provided by the parent. If the context hadn't been provided `use_context` would have panicked.
 
-If you have a component where the context might or not be provided, you might want to use `try_consume_context`instead, so you can handle the `None` case. The drawback of this method is that it will not memoize the value between renders, so it won't be as as efficient as `use_context`, you could do it yourself with `use_hook` though.
+If you have a component where the context might or not be provided, you might want to use `try_consume_context`instead, so you can handle the `None` case. The drawback of this method is that it will not memoize the value between renders, so it won't be as efficient as `use_context`, you could do it yourself with `use_hook` though.
 
 For example, here's how we would implement the dark mode toggle, which both reads the context (to determine what color it should render) and writes to it (to toggle dark mode):
 

--- a/docs-src/0.7/src/essentials/basics/collections.md
+++ b/docs-src/0.7/src/essentials/basics/collections.md
@@ -270,7 +270,7 @@ fn app() -> Element {
     let mut users = use_signal(|| HashMap::<UserId, UserData>::new());
 
     rsx! {
-        // the lifetime here is is not `'static` won't pass to the ListItem component
+        // the lifetime here is not `'static` and won't pass to the ListItem component
         for (id, user) in users.read().iter() {
             ListItem { key: "{id}", user }
         }

--- a/docs-src/0.7/src/essentials/basics/collections.md
+++ b/docs-src/0.7/src/essentials/basics/collections.md
@@ -173,7 +173,7 @@ struct OtherHeaderState {
 let title2 = header.other().title2();
 ```
 
-The ability for a store to "zoom in" through nested datastructures is dependent on whether or not types also implement `Store`. If, for example, or nested structs *didn't* implement the `Store` trait, then we can't lens them:
+The ability for a store to "zoom in" through nested datastructures is dependent on whether or not types also implement `Store`. If, for example, our nested structs *didn't* implement the `Store` trait, then we can't lens them:
 
 ```rust
 #[derive(Store)]

--- a/docs-src/0.7/src/essentials/basics/resources.md
+++ b/docs-src/0.7/src/essentials/basics/resources.md
@@ -158,7 +158,7 @@ Generally, we recommend using `use_resource` when doing client-side fetching and
 
 One common issue when fetching data is the "waterfall" effect, where requests run sequentially. This can lead to slow loading times and a poor user experience. To avoid waterfalls, you can hoist your data loading logic to a higher level in your component tree and avoid returning early before unrelated requests.
 
-Lets look at at an app that causes a waterfall effect:
+Lets look at an app that causes a waterfall effect:
 
 ```rust
 {{#include ../docs-router/src/doc_examples/data_fetching.rs:waterfall_effect}}

--- a/docs-src/0.7/src/essentials/fullstack/axum.md
+++ b/docs-src/0.7/src/essentials/fullstack/axum.md
@@ -103,7 +103,7 @@ The [Axum documentation](https://docs.rs/axum/latest/axum/index.html) has more i
 
 ## Adding `Layers`
 
-Axum allows you to to attach middleware to many parts of your router:
+Axum allows you to attach middleware to many parts of your router:
 
 - To entire routers with [Router::layer](https://docs.rs/axum/latest/axum/struct.Router.html#method.layer) and [Router::route_layer](https://docs.rs/axum/latest/axum/struct.Router.html#method.route_layer).
 - To method routers with [MethodRouter::layer](https://docs.rs/axum/latest/axum/routing/method_routing/struct.MethodRouter.html#method.layer) and [MethodRouter::route_layer](https://docs.rs/axum/latest/axum/routing/method_routing/struct.MethodRouter.html#method.route_layer).

--- a/docs-src/0.7/src/essentials/fullstack/project_setup.md
+++ b/docs-src/0.7/src/essentials/fullstack/project_setup.md
@@ -108,7 +108,7 @@ DX will use these profiles
 
 These profiles correspond 1:1 with the "platforms" DX supports. Note that a `platform` is just a way of DX to isolate two builds from each other. You can completely customize the build, including:
 
-- `--renderer`: swap between the various 1st-party renderers (ie `--renderer native`)
+- `--renderer`: swap between the various 1st-party renderers (i.e., `--renderer native`)
 - `--bundle`: the bundle format of the build (`.app`, `.apk`, `.ipa`, etc.)
 - all cargo options (`--features`, `--target`, `--profile`, `--bin`, etc.)
 

--- a/docs-src/0.7/src/getting_started/index.md
+++ b/docs-src/0.7/src/getting_started/index.md
@@ -8,7 +8,7 @@ Most editors support the [Rust-Analyzer LSP plugin](https://rust-analyzer.github
 
 ## Install Rust
 
-Head over to [https://rust-lang.org](http://rust-lang.org) and install the Rust compiler (preferably using `rustup`). Once installed, make sure you add the `stable` toolchain and any relevant toolchains (ie wasm32-unknown-unknown for web apps):
+Head over to [https://rust-lang.org](http://rust-lang.org) and install the Rust compiler (preferably using `rustup`). Once installed, make sure you add the `stable` toolchain and any relevant toolchains (i.e., wasm32-unknown-unknown for web apps):
 
 ```sh
 rustup toolchain install stable

--- a/docs-src/0.7/src/guides/depth/custom_renderer.md
+++ b/docs-src/0.7/src/guides/depth/custom_renderer.md
@@ -50,7 +50,7 @@ The Dioxus diffing mechanism operates as a [stack machine](https://en.wikipedia.
 
 ## Node storage
 
-Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as as a u64.
+Dioxus saves and loads elements with IDs. Inside the VirtualDOM, this is just tracked as a u64.
 
 Whenever a `CreateElement` edit is generated during diffing, Dioxus increments its node counter and assigns that new element its current NodeCount. The RealDom is responsible for remembering this ID and pushing the correct node when id is used in a mutation. Dioxus reclaims the IDs of elements when removed. To stay in sync with Dioxus you can use a sparse Vec (Vec<Option<T>>) with possibly unoccupied items. You can use the ids as indexes into the Vec for elements, and grow the Vec when an id does not exist.
 

--- a/docs-src/blog/src/release-030.md
+++ b/docs-src/blog/src/release-030.md
@@ -97,7 +97,7 @@ One big advantage of this is the ability to open and close multiple windows from
 
 We’ve expanded what can be considered a component. Lowercase components are now accepted in the rsx macro provided that they either
 
-- Use the path syntax (ie `module::component`)
+- Use the path syntax (i.e., `module::component`)
 - Container an underscore character
 
 This is a similar restriction as found in other frameworks. Note that you still cannot define a one-word component without referencing it via path syntax. We’re hoping to resolve this soon, but it’s not a very easy problem to solve.

--- a/docs-src/blog/src/release-040.md
+++ b/docs-src/blog/src/release-040.md
@@ -381,7 +381,7 @@ Another great contribution from the community: Dioxus desktop now provides funct
 ## Bidirectional Eval
 
 
-The use_eval hook allows you to run snippets of Javascript in your Dioxus application when needed. @doge has made some improvements that make this hook has significantly more powerful. The new version of the hook is compatible between the desktop, web, and Liveview renderers. It also allows you to send messages to and from Javascript asynchronously. This makes it possible to listen for Javascript events that Dioxus doesn’t officially support like the intersection observer API.
+The use_eval hook allows you to run snippets of Javascript in your Dioxus application when needed. @doge has made some improvements that make this hook significantly more powerful. The new version of the hook is compatible between the desktop, web, and Liveview renderers. It also allows you to send messages to and from Javascript asynchronously. This makes it possible to listen for Javascript events that Dioxus doesn’t officially support like the intersection observer API.
 
 ```rust
 use dioxus::prelude::*;

--- a/packages/include_mdbook/packages/mdbook-shared/src/config.rs
+++ b/packages/include_mdbook/packages/mdbook-shared/src/config.rs
@@ -783,7 +783,7 @@ pub struct Fold {
     pub level: u8,
 }
 
-/// Configuration for tweaking how the the HTML renderer handles the playground.
+/// Configuration for tweaking how the HTML renderer handles the playground.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Playground {

--- a/packages/playground/playground/src/components/header.rs
+++ b/packages/playground/playground/src/components/header.rs
@@ -65,7 +65,7 @@ pub fn Header(
                                     .push_error((
                                         "Share Failed",
                                         format!(
-                                            "An error occured while generating a share link: {error:?}",
+                                            "An error occurred while generating a share link: {error:?}",
                                         ),
                                     ));
                             }

--- a/packages/playground/playground/src/hotreload.rs
+++ b/packages/playground/playground/src/hotreload.rs
@@ -43,7 +43,7 @@ pub fn attempt_hot_reload(mut hot_reload: HotReload, new_code: &str) {
         Err(HotReloadError::NeedsRebuild) => hot_reload.set_needs_rebuild(true),
         Err(e) => {
             hot_reload.set_needs_rebuild(true);
-            error!("hot reload error occured: {:?}", e);
+            error!("hot reload error occurred: {:?}", e);
         }
     }
 }

--- a/packages/playground/playground/src/lib.rs
+++ b/packages/playground/playground/src/lib.rs
@@ -237,7 +237,7 @@
 
 //     pub fn push_error(&mut self, error: (impl ToString, impl ToString)) {
 //         let error = (error.0.to_string(), error.1.to_string());
-//         error!(?error, "an error occured and was handled gracefully");
+//         error!(?error, "an error occurred and was handled gracefully");
 //         self.errors.push(error);
 //     }
 


### PR DESCRIPTION
## Summary
- Fix various typos and grammar issues across documentation files
- Corrections span multiple versions (0.3, 0.4, 0.5, 0.6, 0.7) and blog posts
- Also fixes typos in playground and mdbook packages

## Changes
- Fixed typos in 27 files across the codebase
- No functional changes, documentation improvements only

🤖 Generated with [Claude Code](https://claude.com/claude-code)