### PR TITLE
Fix fullstack workspace launch args

### DIFF
--- a/docs-src/0.7/src/essentials/fullstack/project_setup.md
+++ b/docs-src/0.7/src/essentials/fullstack/project_setup.md
@@ -243,7 +243,7 @@ If your server is simple enough, then option 1 can be a decent option since it a
 However, if you choose to have a dedicated server binary, then you'll need to use the `@client` and `@server` modifiers to use a different binary:
 
 ```sh
-dx serve @client --bin dog-app @server --bin pet-api
+dx serve @client --package dog-app @server --package pet-api
 ```
 
 The built-in "Workspace" Dioxus Template can serve as a good starting point for workspace setups.


### PR DESCRIPTION
`--bin` doesn't work in workspaces in the same way that `cargo build --bin` does which can cause this to fail. We should probably fix that in dx, but for now `--package` seems to work correctly