### PR TITLE
Update star count and theme toggle components on Layout-nav

### DIFF
--- a/packages/docsite/src/components/nav.rs
+++ b/packages/docsite/src/components/nav.rs
@@ -115,6 +115,11 @@ pub(crate) fn Nav() -> Element {
 }
 
 fn CurrentStarCount() -> Element {
+    let mut is_client = use_signal(|| false);
+    use_effect(move || {
+        is_client.set(true);
+    });
+
     let num_stars = use_resource(move || async move {
         use crate::awesome::StarsResponse;
         let username = "DioxusLabs";
@@ -124,11 +129,20 @@ fn CurrentStarCount() -> Element {
         Some(res.stargazers_count as usize)
     });
 
-    let mut rendered_stars = 24.5;
-
-    if let Some(Some(loaded)) = num_stars.value()() {
-        let as_float = loaded as f64;
-        rendered_stars = as_float.round() / 1000.0;
+    let mut rendered_stars = 35.8;
+    match num_stars.value()() {
+        Some(Some(loaded)) => {
+            let as_float = loaded as f64;
+            rendered_stars = as_float.round() / 1000.0;
+        }
+        None if is_client() => {
+            return rsx! {
+                span {
+                    class: "inline-block h-4 w-6 rounded bg-gray-300 align-middle animate-pulse dark:bg-gray-600",
+                }
+            };
+        }
+        Some(None) | None => {}
     }
 
     rsx! { "{rendered_stars:.1}k" }

--- a/packages/docsite/src/components/theme.rs
+++ b/packages/docsite/src/components/theme.rs
@@ -58,15 +58,9 @@ pub(crate) fn DarkModeToggle(
             ..attributes,
 
             if dark_mode() {
-                div {
-                    class: "dark:hidden",
-                    DarkModeIcon {}
-                }
+                div { class: "hidden dark:block", LightModeIcon {} }
             } else {
-                div {
-                    class: "hidden dark:hidden",
-                    LightModeIcon {}
-                }
+                div { class: "dark:hidden", DarkModeIcon {} }
             }
         }
     }


### PR DESCRIPTION
two changes:

  1. star count - update default stars `from 25.4 to 25.8`, adding loading fallback on client side
  2. theme toggle - fix wrong class `hidden dark:hidden` to correctify icon display