### PR TITLE
Fix dioxus components embed

### DIFF
--- a/packages/docsite/src/components/component_demo.rs
+++ b/packages/docsite/src/components/component_demo.rs
@@ -12,7 +12,7 @@ pub(crate) fn Components() -> Element {
             .map(|dark_mode| format!("dark_mode={}", dark_mode))
             .unwrap_or_default();
         format!(
-            "https://dioxuslabs.github.io/components/{segments}?iframe=true&{dark_mode}&{query}"
+            "https://dioxuslabs.github.io/dioxus-components/{segments}?iframe=true&{dark_mode}&{query}"
         )
     }
 


### PR DESCRIPTION
The dioxus components repo was renamed changing the github pages url and breaking the iframe. This PR fixes the url to match the new location