### PR TITLE
Improve regex pattern for Tailwind CSS class detection

### DIFF
--- a/docs-src/0.7/src/guides/utilities/tailwind.md
+++ b/docs-src/0.7/src/guides/utilities/tailwind.md
@@ -34,7 +34,7 @@ cargo install dioxus-cli
 2. Go to the settings for the extension and find the experimental regex support section. Edit the setting.json file to look like this:
 
 ```json
-"tailwindCSS.experimental.classRegex": ["class: \"(.*)\""],
+"tailwindCSS.experimental.classRegex": ["class:\\s*\"([\\s\\S]*?)\""],
 "tailwindCSS.includeLanguages": {
     "rust": "html"
 },


### PR DESCRIPTION
Updated the regex pattern for Tailwind CSS class detection in the VSCode extension settings to support rust's multi-line string continuation.

For example, this now works:
```rust
class: "gap-2 border transition-all duration-300 \
                bg-white dark:bg-gray-800"
```