### PR TITLE
docs: update stale dx help output in 0.7 tutorial

### DIFF
--- a/docs-src/0.7/src/tutorial/tooling.md
+++ b/docs-src/0.7/src/tutorial/tooling.md
@@ -23,24 +23,28 @@ dx --version
 
 You can also run `dx help` which will give you a list of useful commands and some information on how to use `dx`.
 
-```txt
-Build, Bundle & Ship Dioxus Apps
+```sh
+Dioxus: build web, desktop, and mobile apps with a single codebase
 
 Usage: dx [OPTIONS] <COMMAND>
 
 Commands:
-  build      Build the Dioxus project and all of its assets
-  translate  Translate a source file into Dioxus code
-  serve      Build, watch & serve the Dioxus project and all of its assets
-  new        Create a new project for Dioxus
-  init       Init a new project for Dioxus in the current directory (by default). Will attempt to keep your project in a good state
-  clean      Clean output artifacts
-  bundle     Bundle the Dioxus app into a shippable object
-  fmt        Automatically format RSX
-  check      Check the project for any issues
-  run        Run the project without any hotreloading
-  config     Dioxus config file controls
-  help       Print this message or the help of the given subcommand(s)
+  new          Create a new Dioxus project
+  serve        Build, watch, and serve the project
+  bundle       Bundle the Dioxus app into a shippable object
+  build        Build the Dioxus project and all of its assets
+  run          Run the project without any hotreloading
+  init         Init a new project for Dioxus in the current directory (by default). Will attempt to keep your project in a good state
+  doctor       Diagnose installed tools and system configuration
+  print        Print project information in a structured format, like cargo args, linker args, and other flags DX sets that might be useful in third-party tools
+  translate    Translate a source file into Dioxus code
+  fmt          Automatically format RSX
+  check        Check the project for any issues
+  config       Dioxus config file controls
+  self-update  Update the Dioxus CLI to the latest version
+  tools        Run a dioxus build tool. IE `build-assets`, `hotpatch`, etc
+  components   Manage components from the `dioxus-component` registry
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --verbose      Use verbose output [default: false]
@@ -48,6 +52,14 @@ Options:
       --json-output  Output logs in JSON format
   -h, --help         Print help
   -V, --version      Print version
+
+Logging Options:
+      --log-to-file <LOG_TO_FILE>  Write *all* logs to a file
+
+Manifest Options:
+      --locked   Assert that `Cargo.lock` will remain unchanged
+      --offline  Run without accessing the network
+      --frozen   Equivalent to specifying both --locked and --offline
 ```
 
 If `dx` is installed properly, then you're ready to proceed!


### PR DESCRIPTION
While continuing to follow the docs after #661, I noticed the 0.7 tutorial tooling page still showed an older `dx help` output with `clean` and without 0.7 commands like `doctor`, `print`, `self-update`, `tools`, and `components`. This updates the tutorial snippet to match the existing 0.7 Tools guide output.