### PR TITLE
Improve Tailwind CSS regex for VSCode extension

### DIFF
--- a/docs-src/0.7/src/essentials/ui/styling.md
+++ b/docs-src/0.7/src/essentials/ui/styling.md
@@ -360,7 +360,7 @@ For better Tailwind development experience, install the Tailwind CSS IntelliSens
 
 ```json
 {
-    "tailwindCSS.experimental.classRegex": ["class: \"(.*)\""],
+    "tailwindCSS.experimental.classRegex": ["(?<!\/\/ ?)class: .*\"(.*)\".*,"],
     "tailwindCSS.includeLanguages": {
         "rust": "html"
     }

--- a/docs-src/0.7/src/guides/utilities/tailwind.md
+++ b/docs-src/0.7/src/guides/utilities/tailwind.md
@@ -34,7 +34,7 @@ cargo install dioxus-cli
 2. Go to the settings for the extension and find the experimental regex support section. Edit the setting.json file to look like this:
 
 ```json
-"tailwindCSS.experimental.classRegex": ["class: \"(.*)\""],
+"tailwindCSS.experimental.classRegex": ["(?<!\/\/ ?)class: .*\"(.*)\".*,"],
 "tailwindCSS.includeLanguages": {
     "rust": "html"
 },


### PR DESCRIPTION
Improved regex for Tailwind CSS class support in VSCode.

Specifically, this now recognizes constructs such as below

```rust
rsx! {
  div {
    class: "bg-<autocomplete triggers>", //this worked before
    class: if truthy { "bg-<autocomplete triggers>" } else { "text-<autocomplete triggers>" }, //this newly works
    // class: "but this is excluded because its a comment", //this *stops* triggering intellisense
  }
}
```

edit: actually in `if truthy { a } else { b }`, only `b` will be detected by this regex, `a` will not match. i dont know how to fix it so whatever,