### PR TITLE
Include BreedResponse in the use_resource example

### DIFF
--- a/docs-src/0.7/src/essentials/basics/resources.md
+++ b/docs-src/0.7/src/essentials/basics/resources.md
@@ -87,6 +87,8 @@ Manually handling edge cases of data loading can be tedious, so we've built a mo
 The [`use_resource`](https://docs.rs/dioxus-hooks/latest/dioxus_hooks/fn.use_resource.html) hook can be used to *derive* asynchronous state. This function accepts an async closure that returns a Future. As the future is polled, `use_resource` tracks `.read()` calls of any contained Signals. If another action calls `.write()` on the tracked signals, the `use_resource` immediately restarts.
 
 ```rust
+{{#include ../docs-router/src/doc_examples/asynchronous.rs:breed_response}}
+
 {{#include ../docs-router/src/doc_examples/asynchronous.rs:use_resource}}
 ```
 

--- a/packages/docs-router/src/doc_examples/asynchronous.rs
+++ b/packages/docs-router/src/doc_examples/asynchronous.rs
@@ -4,6 +4,7 @@ use super::{ComponentWithLogs, log};
 use dioxus::prelude::*;
 use std::collections::HashSet;
 
+// ANCHOR: breed_response
 #[derive(serde::Deserialize, serde::Serialize)]
 struct BreedResponse {
     message: Vec<String>,
@@ -16,6 +17,7 @@ impl std::ops::Deref for BreedResponse {
         &self.message
     }
 }
+// ANCHOR_END: breed_response
 
 pub fn SpawnButton() -> Element {
     // ANCHOR: spawn


### PR DESCRIPTION
## Summary

- expose the existing `BreedResponse` type through a documentation anchor
- include that type before the `use_resource` example body
- keep the type at module scope for the other resource examples that reuse it

Closes #590

## Verification

- `cargo check --workspace --all-features`
- `cargo check -p dioxus-docs-examples`
- `cargo test -p dioxus-docs-examples --lib`
- `cargo clippy -p dioxus-docs-examples --all-targets`
- `rustfmt --edition 2024 --check packages/docs-router/src/doc_examples/asynchronous.rs`