### PR TITLE
Mark recent blog post as draft

### DIFF
--- a/docs-src/blog/src/SUMMARY.md
+++ b/docs-src/blog/src/SUMMARY.md
@@ -9,4 +9,4 @@
 - [Dioxus 0.5 $ Release Notes $ March 21, 2024 $ A signal rewrite, zero unsafe, no lifetimes, unified launch, and more!](release-050.md)
 - [Dioxus 0.6 $ Release Notes $ December 9, 2024 $ Massive Tooling Improvements: Mobile Simulators, Magical Hot-Reloading, Interactive CLI, and more!](release-060.md)
 - [Dioxus 0.7 $ Release Notes $ Sep 8, 2025 $ Hot-Patching, Native Renderer, Bundle Splitting, Radix-UI, more!](release-070.md)
-- [Dioxus Labs is joining Cognition $ Announcement $ September 9, 2026 $ The Dioxus team is joining Cognition to accelerate Devin, and will keep building Dioxus, Blitz, Taffy, and Subsecond.](joining-cognition.md)
+- [Dioxus Labs is joining Cognition [draft] $ Announcement $ September 9, 2026 $ The Dioxus team is joining Cognition to accelerate Devin, and will keep building Dioxus, Blitz, Taffy, and Subsecond.](joining-cognition.md)


### PR DESCRIPTION
## Summary

Marks the "Dioxus Labs is joining Cognition" post as `[draft]` in `docs-src/blog/src/SUMMARY.md`, which `BlogPostItem` in `packages/docsite/src/components/blog.rs` uses to skip unpublished posts — it no longer appears in the blog index.

Note the route `/joining-cognition` is still generated and directly reachable; `[draft]` only hides it from the listing. To publish later, drop the `[draft]` suffix. Verified with `cargo check -p dioxus-docs-blog`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e66215988603410ea49be1f7e595bf9c
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/e66215988603410ea49be1f7e595bf9c?variant=devin-insiders
Requested by: @jkelleyrtp